### PR TITLE
Update README.md to point to ember-concurrency.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A toolset with improved concurrency primitives for Ember.js.
 
-Documentation can be found [here](http://emberconcurrency.com).
+Documentation can be found [here](http://ember-concurrency.com).
 
 ## Addon Maintenance
 


### PR DESCRIPTION
embeconcurrency.com redirects to ember-concurrency.com, so I figured we should just point folks there initially...