### PR TITLE
Bring back ember-load-initializers.

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
+    "ember-load-initializers": "^0.5.1",
     "ember-notify": "5.0.1",
     "ember-power-select": "0.8.6",
     "ember-resolver": "^2.0.3",

--- a/tests/acceptance/root-test.js
+++ b/tests/acceptance/root-test.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+
+moduleForAcceptance('Acceptance | root');
+
+test('visiting /', function(assert) {
+  visit('/');
+
+  andThen(function() {
+    assert.equal(currentURL(), '/');
+    assert.ok(Ember.$('.navbar h3').text(), 'ember-concurrency');
+  });
+});

--- a/tests/helpers/module-for-acceptance.js
+++ b/tests/helpers/module-for-acceptance.js
@@ -1,3 +1,4 @@
+import Ember from 'ember';
 import { module } from 'qunit';
 import startApp from '../helpers/start-app';
 import destroyApp from '../helpers/destroy-app';
@@ -18,6 +19,8 @@ export default function(name, options = {}) {
       if (options.afterEach) {
         options.afterEach.apply(this, arguments);
       }
+
+      Ember.Test.adapter = null;
     }
   });
 }


### PR DESCRIPTION
I missed this when I updated to Ember 2.3.0.  Also added a super simple silly acceptance test that would have caught this...