### PR TITLE
Enable YUIDoc generation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ TODO.md
 
 deploy.sh
 
+/docs

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,3 +1,6 @@
+/**
+ @module ember-concurrency
+*/
 import Ember from 'ember';
 import { isGeneratorIterator, createObservable } from './utils';
 import { TaskProperty, forEach } from './-task-property';
@@ -15,6 +18,11 @@ Ember.assert(`ember-concurrency requires that you set babel.includePolyfill to t
     }
   });`, isGeneratorIterator(testIter));
 
+/**
+  @method task
+  @param func {Function} the generator function backing the task.
+  @returns {TaskProperty}
+*/
 export function task(func) {
   return new TaskProperty(func);
 }
@@ -46,5 +54,3 @@ export function timeout(ms) {
 }
 
 export { createObservable, forEach, Cancelation, all, race };
-
-

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "ember-cli-sass": "^5.2.1",
     "ember-cli-sri": "^2.0.0",
     "ember-cli-uglify": "^1.2.0",
+    "ember-cli-yuidoc": "0.8.3",
     "ember-code-snippet": "^1.1.3",
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-disable-proxy-controllers": "^1.0.1",

--- a/yuidoc.json
+++ b/yuidoc.json
@@ -1,0 +1,16 @@
+{
+  "name": "ember-concurrency",
+  "description": "Improved concurrency/async primitives for Ember.js",
+  "version": "0.5.6",
+  "options": {
+    "paths": [
+      "addon"
+    ],
+    "exclude": "vendor",
+    "outdir": "docs",
+    "linkNatives": true,
+    "quiet": true,
+    "parseOnly": false,
+    "lint": false
+  }
+}


### PR DESCRIPTION
This adds the following commands:

```
ember ember-cli-yuidoc
ember serve --docs
```

Both commands will emit YUIDoc generated JSON and HTML output in `./docs` folder, which can then be published to the website if desired.

There are a number of themes that we can investigate to make the default generated HTML nice enough to include on the site, but in the meantime fleshing out the actual API docs is a great way to make the code base more accessible to newbs (like myself)...