### PR TITLE
Added wait hover example

### DIFF
--- a/tests/dummy/app/components/hover-button/component.js
+++ b/tests/dummy/app/components/hover-button/component.js
@@ -1,0 +1,18 @@
+import Ember from 'ember';
+
+// BEGIN-SNIPPET hover-button
+function sendHover() {
+  this.sendAction('hover');
+}
+
+function sendRelease() {
+  this.sendAction('release');
+}
+
+export default Ember.Component.extend({
+  tagName: 'button',
+
+  mouseEnter: sendHover,
+  mouseLeave: sendRelease,
+});
+// END-SNIPPET

--- a/tests/dummy/app/docs/controller.js
+++ b/tests/dummy/app/docs/controller.js
@@ -23,6 +23,7 @@ export default Ember.Controller.extend({
         {route: "docs.examples.loading-ui", title: "Loading UI"},
         {route: "docs.examples.autocomplete", title: "Auto-Search + ember-power-select"},
         {route: "docs.examples.increment-buttons", title: "Accelerating Increment Buttons"},
+        {route: "docs.examples.wait-hover", title: "Hover Wait"},
         {route: "docs.examples.ajax-throttling", title: "AJAX Throttling"},
         {route: "docs.examples.route-tasks", title: "Route Tasks"},
         {route: "docs.examples.joining-tasks", title: "Awaiting Multiple Child Tasks"},
@@ -76,5 +77,3 @@ export default Ember.Controller.extend({
     }
   }),
 });
-
-

--- a/tests/dummy/app/docs/examples/wait-hover/controller.js
+++ b/tests/dummy/app/docs/examples/wait-hover/controller.js
@@ -1,0 +1,25 @@
+import Ember from 'ember';
+import { task, timeout } from 'ember-concurrency';
+
+// BEGIN-SNIPPET wait-hover-task
+export default Ember.Controller.extend({
+  active: false,
+
+  setActivate() {
+    this.set('active', true);
+  },
+
+  activate: task(function * () {
+    let speed = 600;
+    yield timeout(speed);
+
+    this.setActivate();
+  }),
+
+  actions: {
+    reset() {
+      this.set('active', false);
+    },
+  },
+});
+// END-SNIPPET

--- a/tests/dummy/app/docs/examples/wait-hover/template.hbs
+++ b/tests/dummy/app/docs/examples/wait-hover/template.hbs
@@ -1,0 +1,42 @@
+<h3>Timed Hover Dropdown</h3>
+
+<p>
+  This example demonstrates a few different concepts:
+</p>
+
+<ul>
+  <li>Waiting for a hover time of a certain amount of time</li>
+  <li>
+    Canceling hover timers after <code>mouseLeave</code> events
+  </li>
+</ul>
+
+<h5>Live Example</h5>
+
+<h1>State: {{if active "Active" "Not Active"}}{{count}}</h1>
+
+<p>(Hold down the buttons to accelerate.)</p>
+
+{{! BEGIN-SNIPPET wait-hover }}
+<p>
+  {{#hover-button
+    hover=(perform activate)
+    release=(cancel-all activate)}}
+      Hover To Activate
+  {{/hover-button}}
+
+  <button onclick={{action 'reset'}}>Click to Reset</button>
+</p>
+{{! END-SNIPPET }}
+
+<h5>JavaScript (task)</h5>
+
+{{code-snippet name="wait-hover-task.js"}}
+
+<h5>JavaScript (button component)</h5>
+
+{{code-snippet name="hover-button.js"}}
+
+<h5>Template</h5>
+
+{{code-snippet name="wait-hover.hbs"}}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -16,6 +16,7 @@ Router.map(function() {
     this.route('child-tasks');
     this.route('lifetime');
     this.route('examples', function() {
+      this.route('wait-hover');
       this.route('increment-buttons');
       this.route('loading-ui');
       this.route('autocomplete');


### PR DESCRIPTION
This example shows how ember-concurrency could be used for waiting for hover events.

This could be a common use case in hover UI's since the naive approach for hover is to immediately activate.
But, when thinking about waiting for hovers to be confirmed and the user to stay on an element,
this becomes REALLY hard to manage the timers and canceling.

Luckily, with `ember-concurrency` this is REALLY easy to support.

This could be used for things like showing dynamic tool tips, or dropdowns that wait before activating.