### PR TITLE
small doc grammar fix

### DIFF
--- a/tests/dummy/app/docs/task-function-syntax/template.hbs
+++ b/tests/dummy/app/docs/task-function-syntax/template.hbs
@@ -23,7 +23,7 @@
 <p>
   Much of the power of Tasks is unleashed once you start making
   use of the <code>yield</code> keyword within generator functions.
-  The <code>yield</code> keyword, when used with a promise, let's you
+  The <code>yield</code> keyword, when used with a promise, lets you
   pause execution of your task function until that promise resolves, at
   which point the task function will continue running from where it
   had paused.


### PR DESCRIPTION
Super tiny contribution but thought I'd fix it since I noticed this typo :)

let's = let us
lets = allows

Thanks for making such a cool piece of software :v: