### PR TITLE
fix _findApp by passing in app from included hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,10 +4,10 @@
 module.exports = {
   name: 'ember-concurrency',
 
-  included: function() {
+  included: function(app) {
     this._super.included.apply(this, arguments);
 
-    this._includePolyfill();
+    this._includePolyfill(app);
   },
 
   /*
@@ -16,13 +16,13 @@ module.exports = {
    done once at the top level (we don't want to
    include the polyfill more than once)
    */
-  _includePolyfill: function() {
-    var hostApp = this._findApp();
+  _includePolyfill: function(app) {
+    var hostApp = this._findApp(app);
     hostApp.options.babel.includePolyfill = true;
   },
 
-  _findApp: function() {
-    var app = this.app;
+  _findApp: function(hostApp) {
+    var app = this.app || hostApp;
     while (app.app) {
       app = app.app;
     }


### PR DESCRIPTION
When using ember-concurrency in an addon that is consumed by another app, `this.app` is undefined. Passing in the `app` from the `included` hook to ensure that we've got an app when `this.app` fails. 

This may be limited to earlier versions of ember-cli, as I found the issue while using ember-cli 1.13.13.

@rwjblue 