### PR TITLE
No longer handle cancelation in catch blocks, add didCancel

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,7 @@
 import Ember from 'ember';
 import { isGeneratorIterator, createObservable } from './utils';
 import { TaskProperty } from './-task-property';
+import { didCancel } from './-task-instance';
 import { TaskGroupProperty } from './-task-group';
 import EventedObservable from './-evented-observable';
 import { subscribe } from './-subscribe';
@@ -131,6 +132,7 @@ export {
   enqueue,
   maxConcurrency,
   cancelOn,
-  performOn
+  performOn,
+  didCancel
 };
 

--- a/tests/dummy/app/components/my-button/component.js
+++ b/tests/dummy/app/components/my-button/component.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+import { didCancel } from 'ember-concurrency';
+
 export default Ember.Component.extend({
   click() {
     let val = this.attrs.action(3, 4);
@@ -9,7 +11,7 @@ export default Ember.Component.extend({
         throw new Error("returned value wasn't 10");
       }
     }).catch(e => {
-      if (e.name !== 'TaskCancelation') {
+      if (!didCancel(e)) {
         throw e;
       }
     });

--- a/tests/unit/error-handling-test.js
+++ b/tests/unit/error-handling-test.js
@@ -56,9 +56,8 @@ test("parent task canceled by restartable policy: no errors", function(assert) {
 });
 
 test("parent task perform attempt canceled by drop policy: no errors", function(assert) {
-  assert.expect(5);
+  assert.expect(1);
 
-  let childCancelationCount = 0;
   let childDefer;
   let Obj = Ember.Object.extend({
     parent: task(function * () {
@@ -70,8 +69,7 @@ test("parent task perform attempt canceled by drop policy: no errors", function(
       try {
         yield childDefer.promise;
       } catch(e) {
-        assert.equal(e.name, 'TaskCancelation');
-        childCancelationCount++;
+        assert.ok(false);
       }
     }),
   });
@@ -82,17 +80,14 @@ test("parent task perform attempt canceled by drop policy: no errors", function(
     obj.get('parent').perform(1);
   });
   assert.ok(childDefer);
-  assert.equal(childCancelationCount, 0);
 
   Ember.run(() => {
     obj.get('parent').perform(2);
   });
-  assert.equal(childCancelationCount, 0);
 
   Ember.run(() => {
     obj.get('parent').cancelAll();
   });
-  assert.equal(childCancelationCount, 1);
 });
 
 


### PR DESCRIPTION
Previously, if you had something like

```js
  try {
    yield someChildTask().perform();
  } catch(e) {
    // ...
  }
```

and someChildTask (or the outer task) was canceled,
the catch block would run and you'd be responsible
for differentiating between a cancelation and another
kind of error thrown from someChildTask. This commit
changes these semantics as follows:

1. if you are within a task and you yield another
   (child) task, if the outer task or the child
   task is canceled, then any `catch` blocks
   within the hierarchy of canceled tasks will
   NOT run. In other words, it does not make
   sense to test if an error in a catch block
   is a TaskCancelation, because TaskCancelations
   will never hit catch blocks
2. That said, if you call `.then` or `.catch`
   on a `task.perform()`, then any TaskCancelations
   WILL be passed to the `catch` handler, and if
   it is important to your app to distinguish
   between TaskCancelations and other kinds of
   errors, you should use the new (as of this commit)
   helper function `didCancel` to check if the
   "error" thrown is a TaskCancelation.

With this commit, there should be even less
boilerplate surrounding cancelation than there
used to be.