### PR TITLE
Clarify timeout method usage

### DIFF
--- a/tests/dummy/app/components/start-task-example/component.js
+++ b/tests/dummy/app/components/start-task-example/component.js
@@ -1,10 +1,10 @@
+// BEGIN-SNIPPET start-task-example
 import Ember from 'ember';
 import { task, timeout } from 'ember-concurrency';
 
 export default Ember.Component.extend({
   status: null,
 
-// BEGIN-SNIPPET start-task-example
   myTask: task(function * (msg = "init") {
     let status = `myTask.perform(${msg})...`;
     this.set('status', status);
@@ -25,6 +25,6 @@ export default Ember.Component.extend({
       this.trigger('foo', msg);
     }
   }
-// END-SNIPPET
 });
+// END-SNIPPET
 


### PR DESCRIPTION
- Helps clarify where the timeout method is being imported from for first time users implementing their first task

At first I thought adding a comment with a prefix of `//NOTE: ` would help, but thinking it through - I believe exposing the whole script would make it clearer for those looking to just try out the task without having to reference the API.