### PR TITLE
[Issue #77] maxConcurrency called without specifying a task modifier

### DIFF
--- a/addon/-property-modifiers-mixin.js
+++ b/addon/-property-modifiers-mixin.js
@@ -13,6 +13,8 @@ export const propertyModifiers = {
   _maxConcurrency: Infinity,
   _taskGroupPath: null,
   _hasUsedModifier: false,
+  _hasSetBufferPolicy: false,
+  _hasSetMaxConcurrency: false,
 
   restartable() {
     return setBufferPolicy(this, cancelOngoingTasksPolicy);
@@ -31,6 +33,7 @@ export const propertyModifiers = {
   },
 
   maxConcurrency(n) {
+    this._hasSetMaxConcurrency = true;
     this._hasUsedModifier = true;
     this._maxConcurrency = n;
     assertModifiersNotMixedWithGroup(this);
@@ -45,6 +48,7 @@ export const propertyModifiers = {
 };
 
 function setBufferPolicy(obj, policy) {
+  obj._hasSetBufferPolicy = true;
   obj._hasUsedModifier = true;
   obj._bufferPolicy = policy;
   assertModifiersNotMixedWithGroup(obj);

--- a/addon/-property-modifiers-mixin.js
+++ b/addon/-property-modifiers-mixin.js
@@ -14,7 +14,6 @@ export const propertyModifiers = {
   _taskGroupPath: null,
   _hasUsedModifier: false,
   _hasSetBufferPolicy: false,
-  _hasSetMaxConcurrency: false,
 
   restartable() {
     return setBufferPolicy(this, cancelOngoingTasksPolicy);
@@ -33,7 +32,6 @@ export const propertyModifiers = {
   },
 
   maxConcurrency(n) {
-    this._hasSetMaxConcurrency = true;
     this._hasUsedModifier = true;
     this._maxConcurrency = n;
     assertModifiersNotMixedWithGroup(this);

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -408,6 +408,10 @@ objectAssign(TaskProperty.prototype, propertyModifiers, {
   constructor: TaskProperty,
 
   setup(proto, taskName) {
+    if (this._hasSetMaxConcurrency && !this._hasSetBufferPolicy) {
+      Ember.Logger.warn(`The use of maxConcurrency() without a specified task modifier is deprecated and won't be supported in future versions of ember-concurrency. Please specify a task modifier instead, e.g. \`${taskName}: task(...).enqueue().maxConcurrency(${this._maxConcurrency})\``);
+    }
+    
     registerOnPrototype(Ember.addListener, proto, this.eventNames, taskName, '_perform', false);
     registerOnPrototype(Ember.addListener, proto, this.cancelEventNames, taskName, 'cancelAll', false);
     registerOnPrototype(Ember.addObserver, proto, this._observes, taskName, '_perform', true);

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -408,10 +408,10 @@ objectAssign(TaskProperty.prototype, propertyModifiers, {
   constructor: TaskProperty,
 
   setup(proto, taskName) {
-    if (this._hasSetMaxConcurrency && !this._hasSetBufferPolicy) {
+    if (this._maxConcurrency === Infinity && !this._hasSetBufferPolicy) {
       Ember.Logger.warn(`The use of maxConcurrency() without a specified task modifier is deprecated and won't be supported in future versions of ember-concurrency. Please specify a task modifier instead, e.g. \`${taskName}: task(...).enqueue().maxConcurrency(${this._maxConcurrency})\``);
     }
-    
+
     registerOnPrototype(Ember.addListener, proto, this.eventNames, taskName, '_perform', false);
     registerOnPrototype(Ember.addListener, proto, this.cancelEventNames, taskName, 'cancelAll', false);
     registerOnPrototype(Ember.addObserver, proto, this._observes, taskName, '_perform', true);

--- a/tests/unit/decorators-test.js
+++ b/tests/unit/decorators-test.js
@@ -44,7 +44,7 @@ test(`task accepts maxConcurrency as a decorator arg`, function(assert) {
   assert.expect(1);
 
   let Obj = Ember.Object.extend({
-    myTask: task(maxConcurrency(5), function * () { }),
+    myTask: task(enqueue, maxConcurrency(5), function * () { }),
   });
 
   Ember.run(() => {


### PR DESCRIPTION
## What is this?
If you do ` task(...).maxConcurrency(n)` without applying any other modifier it's not really obvious what the intent is and has led to some confusion. In an effort to clear things up this PR will make it so that a warning (possibly signaling a deprecation) is logged in this scenario.

## What I Did
I created two new flags in the `-property-modifiers-mixin`. One is to track if a modifier was set and the other to track if `maxConcurrency()` was called. Then, in the `setup` hook I check to see if `maxConcurrency()` was called without setting a modifier. If it was I log a warning.

