### PR TITLE
Configure task property definitions (read/write)

### DIFF
--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -418,6 +418,8 @@ objectAssign(TaskProperty.prototype, propertyModifiers, {
 
     let cp = this;
     Object.defineProperty(proto, taskName, {
+      configurable: true,
+      writable: true,
       get() {
         return cp.get(this, taskName);
       }


### PR DESCRIPTION
Make `configurable` and `writable`.

Closes #81