### PR TITLE
Update to ember-getowner-polyfill@1.1.0.

### DIFF
--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -5,7 +5,8 @@ import { TaskGroup } from './-task-group';
 import { propertyModifiers, resolveScheduler } from './-property-modifiers-mixin';
 import { objectAssign, INVOKE, _cleanupOnDestroy, _ComputedProperty } from './utils';
 import EncapsulatedTask from './-encapsulated-task';
-import getOwner from 'ember-getowner-polyfill';
+
+const { getOwner } = Ember;
 
 /**
   The `Task` object lives on a host Ember object (e.g.
@@ -582,4 +583,3 @@ function makeTaskCallback(taskName, method, once) {
     }
   };
 }
-

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
-    "ember-getowner-polyfill": "1.0.1",
+    "ember-getowner-polyfill": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.4"
   },
   "ember-addon": {


### PR DESCRIPTION
Recent changes to ember-getowner-polyfill make it a true polyfill.

This lets us ship the polyfill to only environments that need it, and reduce
boilerplate code in addons.

The refactor is basically just:

```js
import { getOwner } from 'ember-getowner-polyfill';

// ....snip....
getOwner(someThing);
```

To:

```js
import Ember from 'ember';

const { getOwner } = Ember;

// ....snip....
getOwner(someThing);
```