### PR TITLE
Implement withTestWaiter() decorator

### DIFF
--- a/API.md
+++ b/API.md
@@ -28,6 +28,7 @@ under the [Task Property API docs](TaskProperty.html).
 - [drop](TaskProperty.html#drop)
 - [keepLatest](TaskProperty.html#keepLatest)
 - [maxConcurrency](TaskProperty.html#maxConcurrency)
+- [withTestWaiter](TaskProperty.html#withTestWaiter)
 
 
 ## The full API

--- a/addon/-decorators.js
+++ b/addon/-decorators.js
@@ -1,4 +1,4 @@
-let modifierNames = ['restartable', 'drop', 'enqueue', 'maxConcurrency', 'cancelOn'];
+let modifierNames = ['restartable', 'drop', 'enqueue', 'maxConcurrency', 'cancelOn', 'withTestWaiter'];
 let decorators = {};
 
 function makeDecorator(modifierName, methodName) {
@@ -21,4 +21,5 @@ export let enqueue        = decorators.enqueue;
 export let maxConcurrency = decorators.maxConcurrency;
 export let cancelOn       = decorators.cancelOn;
 export let performOn      = decorators.performOn;
+export let withTestWaiter = decorators.withTestWaiter;
 

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -138,6 +138,7 @@ export const Task = Ember.Object.extend(TaskStateMixin, {
   context: null,
   _observes: null,
   _curryArgs: null,
+  _testWaiter: null,
 
   init() {
     this._super(...arguments);
@@ -157,6 +158,11 @@ export const Task = Ember.Object.extend(TaskStateMixin, {
     }
 
     _cleanupOnDestroy(this.context, this, 'cancelAll');
+
+    if (this._testWaiter) {
+      this._registerTestWaiter();
+      _cleanupOnDestroy(this.context, this, '_unregisterTestWaiter');
+    }
   },
 
   _curry(...args) {
@@ -174,6 +180,7 @@ export const Task = Ember.Object.extend(TaskStateMixin, {
       _scheduler: this._scheduler,
       _propertyName: this._propertyName,
       _debugCallback: this._debugCallback,
+      _testWaiter: this._testWaiter,
     });
   },
 
@@ -346,6 +353,14 @@ export const Task = Ember.Object.extend(TaskStateMixin, {
   [INVOKE](...args) {
     return this.perform(...args);
   },
+
+  _registerTestWaiter() {
+    Ember.Test.registerWaiter(this, this._testWaiter);
+  },
+
+  _unregisterTestWaiter() {
+    Ember.Test.unregisterWaiter(this, this._testWaiter);
+  },
 });
 
 /**
@@ -379,6 +394,7 @@ export function TaskProperty(...decorators) {
       //_performsPath,
       _propertyName,
       _debugCallback: tp._debugCallback,
+      _testWaiter: tp._testWaiter,
     });
   });
 
@@ -386,6 +402,7 @@ export function TaskProperty(...decorators) {
   this.cancelEventNames = null;
   this._debugCallback = null;
   this._observes = null;
+  this._testWaiter = null;
 
   for (let i = 0; i < decorators.length; ++i) {
     let decorator = decorators[i];
@@ -470,6 +487,27 @@ objectAssign(TaskProperty.prototype, propertyModifiers, {
   cancelOn() {
     this.cancelEventNames = this.cancelEventNames || [];
     this.cancelEventNames.push.apply(this.cancelEventNames, arguments);
+    return this;
+  },
+
+  /**
+   * When Ember.testing is true, this will cause the task to register a
+   * [test waiter](http://emberjs.com/api/classes/Ember.Test.html#method_registerWaiter)
+   * that waits if the task isn't idle. This allows asynchronous test helpers
+   * to wait for this task to complete, the same as they wait for route
+   * transitions, timers, etc.
+   *
+   * This is useful when your task performs asynchronous operations that aren't
+   * already tracked by Ember.
+   *
+   * @method withTestWaiter
+   * @memberof TaskProperty
+   * @instance
+   */
+  withTestWaiter() {
+    if (Ember.testing) {
+      this._testWaiter = testWaiter;
+    }
     return this;
   },
 
@@ -582,4 +620,8 @@ function makeTaskCallback(taskName, method, once) {
       task[method].apply(task, arguments);
     }
   };
+}
+
+function testWaiter() {
+  return this.get('isIdle');
 }

--- a/addon/index.js
+++ b/addon/index.js
@@ -6,7 +6,7 @@ import { TaskGroupProperty } from './-task-group';
 import EventedObservable from './-evented-observable';
 import { subscribe } from './-subscribe';
 import { all, allSettled, race } from './-yieldables';
-import { drop, restartable, enqueue, maxConcurrency, cancelOn, performOn } from './-decorators';
+import { drop, restartable, enqueue, maxConcurrency, cancelOn, performOn, withTestWaiter } from './-decorators';
 
 let testGenFn = function * () {};
 let testIter = testGenFn();
@@ -134,6 +134,7 @@ export {
   maxConcurrency,
   cancelOn,
   performOn,
+  withTestWaiter,
   didCancel
 };
 

--- a/tests/unit/task-test.js
+++ b/tests/unit/task-test.js
@@ -4,6 +4,16 @@ import { module, test } from 'qunit';
 
 module('Unit: task');
 
+function checkWaiters() {
+  // pre-2.8 the Ember.Test.checkWaiters() API didn't exist, but the
+  // Ember.test.waiters intimate API did.
+  if (Ember.Test.checkWaiters) {
+    return Ember.Test.checkWaiters();
+  } else {
+    return !!Ember.A(Ember.Test.waiters).find(([context, fn]) => !fn.call(context));
+  }
+}
+
 test("task init", function(assert) {
   assert.expect(3);
 
@@ -121,6 +131,155 @@ test("task().cancelOn", function(assert) {
   Ember.run(() => {
     Obj.create().trigger('foo');
   });
+});
+
+test("no test waiter is registered without withTestWaiter() decorator", function(assert) {
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * () {
+      return new Ember.RSVP.Promise((resolve) => null);
+    }),
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  assert.notOk(checkWaiters());
+});
+
+test("withTestWaiter() decorator works", function(assert) {
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * () {
+      return new Ember.RSVP.Promise((resolve) => {
+        this.resolvePromise = resolve;
+      });
+    }).withTestWaiter(),
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while task is running");
+
+  Ember.run(() => {
+    obj.resolvePromise();
+  });
+
+  assert.notOk(checkWaiters(), "waiters are settled after task completes");
+});
+
+test("withTestWaiter() decorator works with concurrent tasks", function(assert) {
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * () {
+      return new Ember.RSVP.Promise((resolve) => {
+        this.resolvePromises = this.resolvePromises || [];
+        this.resolvePromises.push(resolve);
+      });
+    }).withTestWaiter(),
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while task is running");
+
+  Ember.run(() => {
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while two concurrent tasks are running");
+
+  Ember.run(() => {
+    obj.resolvePromises[0]();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled after only one task completes");
+
+  Ember.run(() => {
+    obj.resolvePromises[1]();
+  });
+
+  assert.notOk(checkWaiters(), "waiters are settled after both tasks complete");
+});
+
+test("withTestWaiter() decorator works with restartable()", function(assert) {
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * () {
+      return new Ember.RSVP.Promise((resolve) => {
+        this.resolvePromise = resolve;
+      });
+    }).restartable().withTestWaiter(),
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while task is running");
+
+  Ember.run(() => {
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled after restarting task");
+
+  Ember.run(() => {
+    obj.resolvePromise();
+  });
+
+  assert.notOk(checkWaiters(), "waiters are settled after task completes");
+});
+
+test("withTestWaiter() decorator works with enqueue()", function(assert) {
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * () {
+      return new Ember.RSVP.Promise((resolve) => {
+        this.resolvePromises = this.resolvePromises || [];
+        this.resolvePromises.push(resolve);
+      });
+    }).enqueue().withTestWaiter(),
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while task is running");
+
+  Ember.run(() => {
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while task is queued");
+
+  Ember.run(() => {
+    obj.resolvePromises[0]();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled after only one task completes");
+
+  Ember.run(() => {
+    obj.resolvePromises[1]();
+  });
+
+  assert.notOk(checkWaiters(), "waiters are settled after both tasks complete");
 });
 
 test(".observes re-performs the task every time the observed property changes in a coalesced manner", function(assert) {


### PR DESCRIPTION
The withTestWaiter() decorator instructs a task to register a test waiting that checks if it's idle, so that asynchronous helpers in tests will wait for the task to complete.