### PR TITLE
Make TaskGroup.isRunning also return a boolean

### DIFF
--- a/addon/-task-group.js
+++ b/addon/-task-group.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+const { computed } = Ember;
 import { objectAssign, _ComputedProperty } from './utils';
 import TaskStateMixin from './-task-state-mixin';
 import { propertyModifiers, resolveScheduler } from './-property-modifiers-mixin';
@@ -9,9 +10,9 @@ export const TaskGroup = Ember.Object.extend(TaskStateMixin, {
     return `<TaskGroup:${this._propertyName}>`;
   },
 
-  // FIXME: this is hacky and perhaps wrong
-  isRunning: Ember.computed.or('numRunning', 'numQueued'),
-  isQueued:  false,
+  _numRunningOrNumQueued: computed.or('numRunning', 'numQueued'),
+  isRunning: computed.bool('_numRunningOrNumQueued'),
+  isQueued:  false
 });
 
 export function TaskGroupProperty(...decorators) {
@@ -34,4 +35,3 @@ TaskGroupProperty.prototype = Object.create(_ComputedProperty.prototype);
 objectAssign(TaskGroupProperty.prototype, propertyModifiers, {
   constructor: TaskGroupProperty,
 });
-

--- a/tests/unit/task-groups-test.js
+++ b/tests/unit/task-groups-test.js
@@ -122,3 +122,26 @@ test("task groups can be cancelled", function(assert) {
   assertStates(assert, taskB, false, false, true, suffix);
 });
 
+test("task groups return a boolean for isRunning", function(assert) {
+  assert.expect(3);
+
+  let contextResolve;
+  let defer = Ember.RSVP.defer()
+
+  let Obj = Ember.Object.extend({
+    tg: taskGroup().enqueue(),
+
+    myTask: task(function * () {
+      yield defer.promise;
+    }).group('tg')
+  });
+
+  let obj = Obj.create();
+  let tg = obj.get('tg');
+  let myTask = obj.get('myTask');
+  assert.strictEqual(tg.get('isRunning'), false);
+  Em.run(() => myTask.perform());
+  assert.strictEqual(tg.get('isRunning'), true);
+  Ember.run(defer, defer.resolve);
+  assert.strictEqual(tg.get('isRunning'), false);
+});


### PR DESCRIPTION
`isRunning` on a TaskGroup returns an `Ember.computed.or` of two integers. Unfortunately, `Ember.computed.or` performs `||` which does not guarantee a `boolean`, so this leads to this truth table for `numRunning` and `numQueued`:

```
| numRunning | numQueued | isRunning |
|------------|-----------|-----------|
| 0          | 0         | 0         |
| 1          | 0         | 1         |
| 0          | 1         | 1         |
| 1          | 1         | 1         |
| 2          | 1         | 2         |
| 1          | 2         | 1         |
| ...        | ...       | ...       |
```

This PR changes this to:

```
| numRunning | numQueued | isRunning |
|------------|-----------|-----------|
| 0          | 0         | false     |
| 1          | 0         | true      |
| 0          | 1         | true      |
| 1          | 1         | true      |
| 2          | 1         | true      |
| 1          | 2         | true      |
| ...        | ...       | ...       |
```