### PR TITLE
Support task decorators wrapping the task function

### DIFF
--- a/addon/-decorators.js
+++ b/addon/-decorators.js
@@ -1,7 +1,7 @@
 let modifierNames = ['restartable', 'drop', 'enqueue', 'maxConcurrency', 'cancelOn'];
 let decorators = {};
 
-function makeDecorator(modifierName, methodName) {
+export function makeDecorator(modifierName, methodName) {
   let fn = (...args) => {
     return (taskProperty) => taskProperty[methodName](...args);
   };

--- a/addon/-decorators.js
+++ b/addon/-decorators.js
@@ -1,7 +1,7 @@
 let modifierNames = ['restartable', 'drop', 'enqueue', 'maxConcurrency', 'cancelOn'];
 let decorators = {};
 
-export function makeDecorator(modifierName, methodName) {
+function makeDecorator(modifierName, methodName) {
   let fn = (...args) => {
     return (taskProperty) => taskProperty[methodName](...args);
   };

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -365,13 +365,12 @@ export const Task = Ember.Object.extend(TaskStateMixin, {
   @class TaskProperty
 */
 export function TaskProperty(...decorators) {
-  let taskFn = decorators.pop();
   let _performsPath;
 
   let tp = this;
   _ComputedProperty.call(this, function(_propertyName) {
     return Task.create({
-      fn: taskFn,
+      fn: tp.taskFn,
       context: this,
       _origin: this,
       _taskGroupPath: tp._taskGroupPath,
@@ -382,6 +381,7 @@ export function TaskProperty(...decorators) {
     });
   });
 
+  this.taskFn = decorators.pop();
   this.eventNames = null;
   this.cancelEventNames = null;
   this._debugCallback = null;

--- a/tests/unit/task-property-test.js
+++ b/tests/unit/task-property-test.js
@@ -1,0 +1,194 @@
+import Ember from 'ember';
+import { task, interval } from 'ember-concurrency';
+import { TaskProperty } from 'ember-concurrency/-task-property';
+import { module, test } from 'qunit';
+
+module('Unit: task property', {
+  beforeEach() {
+    let taskRunCounter = 0;
+    this.waiter = () => taskRunCounter === 0;
+
+    Ember.Test.registerWaiter(this.waiter);
+
+    TaskProperty.prototype.withTestWaiter = function() {
+      if (Ember.testing) {
+        let originalTaskFn = this.taskFn;
+
+        this.taskFn = function * (...args) {
+          taskRunCounter += 1;
+          try {
+            return yield * originalTaskFn.apply(this, args);
+          } finally {
+            taskRunCounter -= 1;
+          }
+        };
+      }
+
+      return this;
+    }
+  },
+
+  afterEach() {
+    Ember.Test.unregisterWaiter(this.waiter);
+    delete TaskProperty.prototype.withTestWaiter;
+  }
+});
+
+function checkWaiters() {
+  // pre-2.8 the Ember.Test.checkWaiters() API didn't exist, but the
+  // Ember.test.waiters intimate API did.
+  if (Ember.Test.checkWaiters) {
+    return Ember.Test.checkWaiters();
+  } else {
+    return !!Ember.A(Ember.Test.waiters).find(([context, fn]) => !fn.call(context));
+  }
+}
+
+test("waiters are settled without withTestWaiter() decorator", function(assert) {
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * () {
+      return yield new Ember.RSVP.Promise((resolve) => null);
+    }),
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  assert.notOk(checkWaiters());
+});
+
+test("withTestWaiter() decorator works", function(assert) {
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * () {
+      return yield new Ember.RSVP.Promise((resolve) => {
+        this.resolvePromise = resolve;
+      });
+    }).withTestWaiter(),
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while task is running");
+
+  Ember.run(() => {
+    obj.resolvePromise();
+  });
+
+  assert.notOk(checkWaiters(), "waiters are settled after task completes");
+});
+
+test("withTestWaiter() decorator works with concurrent tasks", function(assert) {
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * () {
+      return yield new Ember.RSVP.Promise((resolve) => {
+        this.resolvePromises = this.resolvePromises || [];
+        this.resolvePromises.push(resolve);
+      });
+    }).withTestWaiter(),
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while task is running");
+
+  Ember.run(() => {
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while two concurrent tasks are running");
+
+  Ember.run(() => {
+    obj.resolvePromises[0]();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled after only one task completes");
+
+  Ember.run(() => {
+    obj.resolvePromises[1]();
+  });
+
+  assert.notOk(checkWaiters(), "waiters are settled after both tasks complete");
+});
+
+test("withTestWaiter() decorator works with restartable()", function(assert) {
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * () {
+      return yield new Ember.RSVP.Promise((resolve) => {
+        this.resolvePromise = resolve;
+      });
+    }).restartable().withTestWaiter(),
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while task is running");
+
+  Ember.run(() => {
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled after restarting task");
+
+  Ember.run(() => {
+    obj.resolvePromise();
+  });
+
+  assert.notOk(checkWaiters(), "waiters are settled after task completes");
+});
+
+test("withTestWaiter() decorator works with enqueue()", function(assert) {
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * () {
+      return yield new Ember.RSVP.Promise((resolve) => {
+        this.resolvePromises = this.resolvePromises || [];
+        this.resolvePromises.push(resolve);
+      });
+    }).enqueue().withTestWaiter(),
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while task is running");
+
+  Ember.run(() => {
+    obj.get('doStuff').perform();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled while task is queued");
+
+  Ember.run(() => {
+    obj.resolvePromises[0]();
+  });
+
+  assert.ok(checkWaiters(), "waiters are not settled after only one task completes");
+
+  Ember.run(() => {
+    obj.resolvePromises[1]();
+  });
+
+  assert.notOk(checkWaiters(), "waiters are settled after both tasks complete");
+});


### PR DESCRIPTION
Implement support for defining new task property modifier methods to decorate/wrap the task function itself. The `task-property-test` unit tests demonstrate how to use this to implement functionality to register a test waiter to allow tests to wait anytime certain tasks are running.