### PR TITLE
Add isSuccessful and isError to TaskInstance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+### master
+  - More derived state: Task Instances now have an additional
+    `isSuccessful` and `isError` property
+
 ### 0.7.19
   - Added the ability to extend/wrap/decorate `TaskProperty`s (the
     value returned from `task()`, so that things like task test


### PR DESCRIPTION
This PR adds two more derived properties to TaskInstances:

`isSuccessful`: true if the task fulfills, that is it completes without error or cancelling.
`isError`: true if the task resolves to a rejection 