### PR TITLE
Make `all`, `allSettled`, `race` helpers support to cancel promises w…

### DIFF
--- a/addon/-yieldables.js
+++ b/addon/-yieldables.js
@@ -67,6 +67,8 @@ function taskAwareVariantOf(obj, method) {
       items.forEach(it => {
         if (it instanceof TaskInstance) {
           it.cancel();
+        } else if (typeof it.__ec_cancel__ === 'function') {
+          it.__ec_cancel__();
         }
       });
     };


### PR DESCRIPTION
…ith `__ec_cancel__`.

this would ensure these helpers to have same behaviors in normal `async` functions as in tasks.