### PR TITLE
remove unnecessary assertion

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,21 +1,11 @@
 import Ember from 'ember';
-import { isGeneratorIterator, timeout } from './utils';
+import { timeout } from './utils';
 import { TaskProperty } from './-task-property';
 import { didCancel } from './-task-instance';
 import { TaskGroupProperty } from './-task-group';
 import EventedObservable from './-evented-observable';
 import { all, allSettled, hash, race } from './-cancelable-promise-helpers';
 import { waitForQueue, waitForEvent } from './-wait-for';
-
-let testGenFn = function * () {};
-let testIter = testGenFn();
-Ember.assert(`ember-concurrency requires that you set babel.includePolyfill to true in your ember-cli-build.js (or Brocfile.js) to ensure that the generator function* syntax is properly transpiled, e.g.:
-
-  var app = new EmberApp({
-    babel: {
-      includePolyfill: true,
-    }
-  });`, isGeneratorIterator(testIter));
 
 /**
  * A Task is a cancelable, restartable, asynchronous operation that

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -1,12 +1,5 @@
 import Ember from 'ember';
 
-export function isGeneratorIterator(iter) {
-  return (iter &&
-          typeof iter.next      === 'function' &&
-          typeof iter['return'] === 'function' &&
-          typeof iter['throw']  === 'function');
-}
-
 export function isEventedObject(c) {
   return (c &&
           typeof c.one === 'function' &&


### PR DESCRIPTION
EC has `ember-maybe-import-regenerator` since 0.7.5, the generator function is provided by default. We can remove the generator testing code.