### PR TITLE
[docs] add active style on side menu

### DIFF
--- a/tests/dummy/app/docs/controller.js
+++ b/tests/dummy/app/docs/controller.js
@@ -6,7 +6,7 @@ export default Ember.Controller.extend({
   appController: Ember.inject.controller('application'),
 
   tableOfContents: [
-    { route: "docs",   title: "Introduction"},
+    { route: "docs.introduction", title: "Introduction"},
     { route: "docs.installation", title: "Installation"},
     { route: "docs.writing-tasks", title: "Your First Task"},
     { route: "docs.task-function-syntax", title: "Task Function Syntax"},
@@ -83,5 +83,3 @@ export default Ember.Controller.extend({
     }
   }),
 });
-
-

--- a/tests/dummy/app/docs/index/route.js
+++ b/tests/dummy/app/docs/index/route.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+export default Ember.Route.extend({
+  redirect() {
+    this.transitionTo('docs.introduction');
+  }
+});

--- a/tests/dummy/app/docs/introduction/template.hbs
+++ b/tests/dummy/app/docs/introduction/template.hbs
@@ -97,4 +97,3 @@
     individually cancelable units
   </li>
 </ul>
-

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -7,6 +7,7 @@ const Router = Ember.Router.extend({
 
 Router.map(function() {
   this.route('docs', function() {
+    this.route('introduction');
     this.route('installation');
     this.route('writing-tasks');
     this.route('task-function-syntax');

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -11,9 +11,12 @@ section {
   margin-top: 10rem;
 }
 
+a {
+  text-decoration: none;
+}
+
 .navbar {
   a {
-    text-decoration: none;
     color: black;
     line-height: 6rem;
     padding: 2rem 2rem;
@@ -30,6 +33,11 @@ section {
 
 .side-menu {
   padding-left: 2rem;
+
+  .active {
+    font-weight: bold;
+    text-decoration: underline;
+  }
 }
 
 .progress-outer {
@@ -147,4 +155,3 @@ th, td {
     opacity: 1;
   }
 }
-


### PR DESCRIPTION
- created new route `introduction` & moved the template from `index` to `introduction`
- removed `underline` style from links
- added `active` style (bold + underline) on side-menu links

![image](https://cloud.githubusercontent.com/assets/205137/25598936/3d197490-2ea6-11e7-8e8e-fb272d0fedba.png)
