### PR TITLE
[docs] show addon version in docs

### DIFF
--- a/tests/dummy/app/application/controller.js
+++ b/tests/dummy/app/application/controller.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+import config from '../config/environment';
+
+const versionRegExp = /\d[.]\d[.]\d/;
+const {
+  APP: { version }
+} = config;
+
+export default Ember.Controller.extend({
+  addonVersion: version.match(versionRegExp)[0]
+});

--- a/tests/dummy/app/application/template.hbs
+++ b/tests/dummy/app/application/template.hbs
@@ -1,7 +1,10 @@
 <div class="container navbar">
   <div class="row">
     <div class="ten columns">
-      <h3>ember-concurrency</h3>
+      <h3>
+        ember-concurrency
+        {{#link-to "docs" class="button button-primary"}}v {{addonVersion}}{{/link-to}}
+      </h3>
     </div>
     <div class="one columns">
       <div class="nav-bar-link-outer">
@@ -19,4 +22,3 @@
 {{outlet}}
 
 {{ember-notify}}
-

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -12,7 +12,7 @@ section {
 }
 
 .navbar {
-  a {
+  .nav-bar-link-outer a {
     text-decoration: none;
     color: black;
     line-height: 6rem;
@@ -147,4 +147,3 @@ th, td {
     opacity: 1;
   }
 }
-


### PR DESCRIPTION
Added addon's version in the docs so people can notice that which version they're on. That would be great if there's a select box to choose docs by different versions. Baby steps!

![screen shot 2017-05-01 at 7 48 18 pm](https://cloud.githubusercontent.com/assets/205137/25599063/4ac3434a-2ea7-11e7-9698-b29755c8d6c0.png)
