### PR TITLE
Support null/undefined values in cancelable promise helpers

### DIFF
--- a/addon/-cancelable-promise-helpers.js
+++ b/addon/-cancelable-promise-helpers.js
@@ -116,10 +116,12 @@ function taskAwareVariantOf(obj, method, getItems) {
       if (hasCancelled) { return; }
       hasCancelled = true;
       items.forEach(it => {
-        if (it instanceof TaskInstance) {
-          it.cancel();
-        } else if (typeof it.__ec_cancel__ === 'function') {
-          it.__ec_cancel__();
+        if (it) {
+          if (it instanceof TaskInstance) {
+            it.cancel();
+          } else if (typeof it.__ec_cancel__ === 'function') {
+            it.__ec_cancel__();
+          }
         }
       });
     };
@@ -129,4 +131,3 @@ function taskAwareVariantOf(obj, method, getItems) {
     return promise;
   };
 }
-

--- a/tests/unit/cancelable-promise-helpers-test.js
+++ b/tests/unit/cancelable-promise-helpers-test.js
@@ -307,6 +307,31 @@ test("hash cancels children if parent is canceled", function(assert) {
   assert.equal(obj.get('child.concurrency'), 0);
 });
 
+test("yieldable helpers work with null/undefined values", function(assert) {
+  assert.expect(1);
+
+  let Obj = Ember.Object.extend({
+    parent: task(function * () {
+      let task = this.get('child');
+      let obj = Ember.Object.create();
+      let v = yield hash({
+        a: task.perform(1),
+        b: null,
+        c: undefined
+      });
+      assert.deepEqual(v, { a: 1, b: null, c: undefined });
+    }),
+
+    child: task(function * (v) { return v; }),
+  });
+
+  let obj;
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('parent').perform();
+  });
+});
+
 test("yieldable helpers support to cancel promises with __ec_cancel__", function(assert) {
   assert.expect(1);
 


### PR DESCRIPTION
Similarly to how it's very nice to be able to pass a mix of promises and simple values to Ember.RSVP.{hash,all}, it's nice to be able to pass a mix of task results and simple values to ember-concurrency's hash() and all() helpers. However, if one of these values were null or undefined, the cancellation code would throw an error. This fixes that.