### PR TITLE
`enqueueWithPriority` task modifier

### DIFF
--- a/addon/-buffer-policy.js
+++ b/addon/-buffer-policy.js
@@ -24,7 +24,7 @@ export const enqueueTasksPolicy = {
   }
 };
 
-export const enqueuePriorityPolicy = {
+export const enqueueWithPriorityPolicy = {
   requiresUnboundedConcurrency: true,
   schedule(scheduler) {
     scheduler.queuedTaskInstances.sort(this.sortFunc);

--- a/addon/-buffer-policy.js
+++ b/addon/-buffer-policy.js
@@ -24,6 +24,17 @@ export const enqueueTasksPolicy = {
   }
 };
 
+export const enqueuePriorityPolicy = {
+  requiresUnboundedConcurrency: true,
+  schedule(scheduler) {
+    scheduler.queuedTaskInstances.sort(this.sortFunc);
+    saturateActiveQueue(scheduler);
+  },
+  getNextPerformStatus(scheduler) {
+    return numPerformSlots(scheduler) > 0 ? 'succeed' : 'enqueue';
+  }
+};
+
 export const dropQueuedTasksPolicy = {
   cancelReason: `it belongs to a 'drop' Task that was already running`,
   schedule(scheduler) {

--- a/addon/-property-modifiers-mixin.js
+++ b/addon/-property-modifiers-mixin.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import Scheduler from './-scheduler';
 import {
   enqueueTasksPolicy,
-  enqueuePriorityPolicy,
+  enqueueWithPriorityPolicy,
   dropQueuedTasksPolicy,
   cancelOngoingTasksPolicy,
   dropButKeepLatestPolicy
@@ -24,8 +24,8 @@ export const propertyModifiers = {
     return setBufferPolicy(this, enqueueTasksPolicy);
   },
 
-  enqueuePriority(sortFunc) {
-    return setBufferPolicy(this, Object.assign({ sortFunc }, enqueuePriorityPolicy));
+  enqueueWithPriority(sortFunc) {
+    return setBufferPolicy(this, Object.assign({ sortFunc }, enqueueWithPriorityPolicy));
   },
 
   drop() {

--- a/addon/-property-modifiers-mixin.js
+++ b/addon/-property-modifiers-mixin.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import Scheduler from './-scheduler';
 import {
   enqueueTasksPolicy,
+  enqueuePriorityPolicy,
   dropQueuedTasksPolicy,
   cancelOngoingTasksPolicy,
   dropButKeepLatestPolicy
@@ -21,6 +22,10 @@ export const propertyModifiers = {
 
   enqueue() {
     return setBufferPolicy(this, enqueueTasksPolicy);
+  },
+
+  enqueuePriority(sortFunc) {
+    return setBufferPolicy(this, Object.assign({ sortFunc }, enqueuePriorityPolicy));
   },
 
   drop() {

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -463,6 +463,19 @@ objectAssign(TaskProperty.prototype, propertyModifiers, {
    */
 
   /**
+   * Like {@linkcode TaskProperty#enqueue .enqueue()} but allows you
+   * to pass a `sortFunc` which can control the order of execution of
+   * the items in the queue.
+   *
+   * [See the advanced concurrency example](/#/docs/task-concurrency-advanced)
+   *
+   * @method enqueuePriority
+   * @memberof TaskProperty
+   * @param {Function} sortFunc The maximum number of concurrently running tasks
+   * @instance
+   */
+
+  /**
    * Configures the task to immediately cancel (i.e. drop) any
    * task instances performed when the task is already running
    * at maxConcurrency. Sets default maxConcurrency to 1.

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -469,7 +469,7 @@ objectAssign(TaskProperty.prototype, propertyModifiers, {
    *
    * [See the advanced concurrency example](/#/docs/task-concurrency-advanced)
    *
-   * @method enqueuePriority
+   * @method enqueueWithPriority
    * @memberof TaskProperty
    * @param {Function} sortFunc The maximum number of concurrently running tasks
    * @instance

--- a/tests/dummy/app/docs/task-concurrency-advanced/controller.js
+++ b/tests/dummy/app/docs/task-concurrency-advanced/controller.js
@@ -17,9 +17,13 @@ export default Ember.Controller.extend({
   enqueuedTask3:    task(SHARED_TASK_FN).maxConcurrency(3).enqueue(),
   droppingTask3:    task(SHARED_TASK_FN).maxConcurrency(3).drop(),
   keepLatestTask3:  task(SHARED_TASK_FN).maxConcurrency(3).keepLatest(),
-  priorityTask:    task(SHARED_TASK_FN).enqueuePriority((a, b) => {
-    return b.args[0].performTime - a.args[0].performTime;
-  }),
+  priorityTask:     task(SHARED_TASK_FN).enqueuePriority(prioritySortFn),
+  priorityTask3:    task(SHARED_TASK_FN).maxConcurrency(3).enqueuePriority(prioritySortFn),
 });
+
+// An example sort function which sorts tasks based on the perform time descending
+function prioritySortFn(a, b) {
+  return b.args[0].performTime - a.args[0].performTime;
+}
 // END-SNIPPET
 

--- a/tests/dummy/app/docs/task-concurrency-advanced/controller.js
+++ b/tests/dummy/app/docs/task-concurrency-advanced/controller.js
@@ -17,8 +17,8 @@ export default Ember.Controller.extend({
   enqueuedTask3:    task(SHARED_TASK_FN).maxConcurrency(3).enqueue(),
   droppingTask3:    task(SHARED_TASK_FN).maxConcurrency(3).drop(),
   keepLatestTask3:  task(SHARED_TASK_FN).maxConcurrency(3).keepLatest(),
-  priorityTask:     task(SHARED_TASK_FN).enqueuePriority(prioritySortFn),
-  priorityTask3:    task(SHARED_TASK_FN).maxConcurrency(3).enqueuePriority(prioritySortFn),
+  priorityTask:     task(SHARED_TASK_FN).enqueueWithPriority(prioritySortFn),
+  priorityTask3:    task(SHARED_TASK_FN).maxConcurrency(3).enqueueWithPriority(prioritySortFn),
 });
 
 // An example sort function which sorts tasks based on the perform time descending

--- a/tests/dummy/app/docs/task-concurrency-advanced/controller.js
+++ b/tests/dummy/app/docs/task-concurrency-advanced/controller.js
@@ -17,6 +17,9 @@ export default Ember.Controller.extend({
   enqueuedTask3:    task(SHARED_TASK_FN).maxConcurrency(3).enqueue(),
   droppingTask3:    task(SHARED_TASK_FN).maxConcurrency(3).drop(),
   keepLatestTask3:  task(SHARED_TASK_FN).maxConcurrency(3).keepLatest(),
+  priorityTask:    task(SHARED_TASK_FN).enqueuePriority((a, b) => {
+    return b.args[0].performTime - a.args[0].performTime;
+  }),
 });
 // END-SNIPPET
 

--- a/tests/dummy/app/docs/task-concurrency-advanced/template.hbs
+++ b/tests/dummy/app/docs/task-concurrency-advanced/template.hbs
@@ -52,7 +52,7 @@
 
 {{concurrency-graph task=keepLatestTask3}}
 
-<h4>.enqueuePriority()</h4>
+<h3>Using <code>.enqueuePriority(sortFunc)</code></h3>
 
 <p>
   The <code>enqueuePriority</code> modifier acts like `enqueue` but
@@ -61,12 +61,20 @@
   next task to start running is chosen by the `sortFunc` passed to
   <code>enqueuePriority</code>
 </p>
+
 <p>
-  In this example we simply sort by the perform time descending so that
+  In these examples we simply sort by the perform time descending so that
   the most recently performed task is chosen to run next.
 </p>
 
+<h4>.enqueuePriority() with default maxConcurrency(1)</h4>
+
 {{concurrency-graph task=priorityTask}}
+
+<h4>.enqueuePriority() with maxConcurrency(3)</h4>
+
+{{concurrency-graph task=priorityTask3}}
+
 <p>
   <em>
     Thanks to <a href="https://github.com/ef4">Edward Faulkner</a> for providing

--- a/tests/dummy/app/docs/task-concurrency-advanced/template.hbs
+++ b/tests/dummy/app/docs/task-concurrency-advanced/template.hbs
@@ -52,14 +52,14 @@
 
 {{concurrency-graph task=keepLatestTask3}}
 
-<h3>Using <code>.enqueuePriority(sortFunc)</code></h3>
+<h3>Using <code>.enqueueWithPriority(sortFunc)</code></h3>
 
 <p>
-  The <code>enqueuePriority</code> modifier acts like `enqueue` but
-  allows you to provide a sort function which sorts the enqueued tasks
+  The <code>enqueueWithPriority</code> modifier acts like <code>enqueue</code>
+  but allows you to provide a sort function which sorts the enqueued tasks
   so that they are run in priority order. Whenever a task finishes the
-  next task to start running is chosen by the `sortFunc` passed to
-  <code>enqueuePriority</code>
+  next task to start running is chosen by the <code>sortFunc</code> passed to
+  <code>enqueueWithPriority</code>
 </p>
 
 <p>
@@ -67,11 +67,11 @@
   the most recently performed task is chosen to run next.
 </p>
 
-<h4>.enqueuePriority() with default maxConcurrency(1)</h4>
+<h4>.enqueueWithPriority() with default maxConcurrency(1)</h4>
 
 {{concurrency-graph task=priorityTask}}
 
-<h4>.enqueuePriority() with maxConcurrency(3)</h4>
+<h4>.enqueueWithPriority() with maxConcurrency(3)</h4>
 
 {{concurrency-graph task=priorityTask3}}
 

--- a/tests/dummy/app/docs/task-concurrency-advanced/template.hbs
+++ b/tests/dummy/app/docs/task-concurrency-advanced/template.hbs
@@ -52,6 +52,21 @@
 
 {{concurrency-graph task=keepLatestTask3}}
 
+<h4>.enqueuePriority()</h4>
+
+<p>
+  The <code>enqueuePriority</code> modifier acts like `enqueue` but
+  allows you to provide a sort function which sorts the enqueued tasks
+  so that they are run in priority order. Whenever a task finishes the
+  next task to start running is chosen by the `sortFunc` passed to
+  <code>enqueuePriority</code>
+</p>
+<p>
+  In this example we simply sort by the perform time descending so that
+  the most recently performed task is chosen to run next.
+</p>
+
+{{concurrency-graph task=priorityTask}}
 <p>
   <em>
     Thanks to <a href="https://github.com/ef4">Edward Faulkner</a> for providing

--- a/tests/unit/priority-queue-test.js
+++ b/tests/unit/priority-queue-test.js
@@ -1,0 +1,92 @@
+import Ember from 'ember';
+import { task } from 'ember-concurrency';
+import { module, test } from 'qunit';
+
+module('Unit: enqueueWithPriority');
+
+test("The `enqueueWithPriority` modifier allows you to control the order that tasks are performed in", function(assert) {
+  let performedTasks = [];
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * (name, priority) {
+      performedTasks.push(name);
+    }).enqueueWithPriority(function(a, b) {
+      let [nameA, priorityA] = a.args;
+      let [nameB, priorityB] = b.args;
+      return priorityB - priorityA;
+    })
+  });
+
+  Ember.run(() => {
+    let obj = Obj.create();
+    obj.get('doStuff').perform('a', 1);
+    obj.get('doStuff').perform('b', 2);
+    obj.get('doStuff').perform('c', 3);
+    obj.get('doStuff').perform('d', 4);
+    obj.get('doStuff').perform('e', 5);
+    obj.get('doStuff').perform('f', 6);
+  });
+
+  Ember.run(() => {
+    assert.deepEqual(performedTasks, ['a', 'f', 'e', 'd', 'c', 'b'], 'Tasks have been sorted as expected');
+  });
+});
+
+test("The `enqueueWithPriority` modifier allows you to control the order that tasks are performed in (2)", function(assert) {
+  let performedTasks = [];
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * (name, priority) {
+      performedTasks.push(name);
+    }).enqueueWithPriority(function(a, b) {
+      let [nameA, priorityA] = a.args;
+      let [nameB, priorityB] = b.args;
+      return priorityB - priorityA;
+    })
+  });
+
+  Ember.run(() => {
+    let obj = Obj.create();
+    obj.get('doStuff').perform('f', 6);
+    obj.get('doStuff').perform('b', 2);
+    obj.get('doStuff').perform('c', 3);
+    obj.get('doStuff').perform('a', 1);
+    obj.get('doStuff').perform('d', 4);
+    obj.get('doStuff').perform('e', 5);
+  });
+
+  Ember.run(() => {
+    assert.deepEqual(performedTasks, ['f', 'e', 'd', 'c', 'b', 'a'], 'Tasks have been sorted as expected');
+  });
+});
+
+test("The `enqueueWithPriority` modifier behaves as expected across runloops", function(assert) {
+  let performedTasks = [];
+  let Obj = Ember.Object.extend({
+    doStuff: task(function * (name, priority) {
+      performedTasks.push(name);
+    }).enqueueWithPriority(function(a, b) {
+      let [nameA, priorityA] = a.args;
+      let [nameB, priorityB] = b.args;
+      return priorityB - priorityA;
+    })
+  });
+
+  let obj;
+
+  Ember.run(() => {
+    obj = Obj.create();
+    obj.get('doStuff').perform('f', 6);
+    obj.get('doStuff').perform('b', 2);
+    obj.get('doStuff').perform('c', 3);
+  });
+
+  Ember.run(() => {
+    obj.get('doStuff').perform('a', 1);
+    obj.get('doStuff').perform('d', 4);
+    obj.get('doStuff').perform('e', 5);
+  });
+
+  Ember.run(() => {
+    assert.deepEqual(performedTasks, ['f', 'c', 'b', 'a', 'e', 'd'], 'Tasks have been sorted as expected');
+  });
+});
+


### PR DESCRIPTION
This modifier would allow you to pass a `sortFunc` which is used to
sort the queue directly before taking any tasks off it. This means that
you can add a bunch of tasks to a queue but mark some as more important
than others.

The contents of this commit are just a spike based of some advice from
@machty in slack. If this general approach makes sense then I could
try to make sense out of the tests and round this out into a more
complete PR...