### PR TITLE
WIP: Add support for multiple task channels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ dist: trusty
 
 cache:
   yarn: true
+  directories:
+      - $HOME/.cache/bower
 
 addons:
   apt:

--- a/addon/-buffer-policy.js
+++ b/addon/-buffer-policy.js
@@ -1,23 +1,25 @@
-const saturateActiveQueue = (scheduler) => {
-  while (scheduler.activeTaskInstances.length < scheduler.maxConcurrency) {
-    let taskInstance = scheduler.queuedTaskInstances.shift();
+import {spliceTaskInstances} from './-scheduler';
+
+const saturateActiveQueue = (maxConcurrency, queuedTaskInstances, activeTaskInstances) => {
+  while (activeTaskInstances.length < maxConcurrency) {
+    let taskInstance = queuedTaskInstances.shift();
     if (!taskInstance) { break; }
-    scheduler.activeTaskInstances.push(taskInstance);
+    activeTaskInstances.push(taskInstance);
   }
 };
 
-function numPerformSlots(scheduler) {
-  return scheduler.maxConcurrency -
-    scheduler.queuedTaskInstances.length -
-    scheduler.activeTaskInstances.length;
+function numPerformSlots(maxConcurrency, queuedTaskInstances, activeTaskInstances) {
+  return maxConcurrency -
+    queuedTaskInstances.length -
+    activeTaskInstances.length;
 }
 
 export const enqueueTasksPolicy = {
   requiresUnboundedConcurrency: true,
-  schedule(scheduler) {
+  schedule(maxConcurrency, queuedTaskInstances, activeTaskInstances) {
     // [a,b,_] [c,d,e,f] becomes
     // [a,b,c] [d,e,f]
-    saturateActiveQueue(scheduler);
+    saturateActiveQueue(maxConcurrency, queuedTaskInstances, activeTaskInstances);
   },
   getNextPerformStatus(scheduler) {
     return numPerformSlots(scheduler) > 0 ? 'succeed' : 'enqueue';
@@ -26,11 +28,11 @@ export const enqueueTasksPolicy = {
 
 export const dropQueuedTasksPolicy = {
   cancelReason: `it belongs to a 'drop' Task that was already running`,
-  schedule(scheduler) {
+  schedule(maxConcurrency, queuedTaskInstances, activeTaskInstances) {
     // [a,b,_] [c,d,e,f] becomes
     // [a,b,c] []
-    saturateActiveQueue(scheduler);
-    scheduler.spliceTaskInstances(this.cancelReason, scheduler.queuedTaskInstances, 0, scheduler.queuedTaskInstances.length);
+    saturateActiveQueue(maxConcurrency, queuedTaskInstances, activeTaskInstances);
+    spliceTaskInstances(this.cancelReason, queuedTaskInstances, 0, queuedTaskInstances.length);
   },
   getNextPerformStatus(scheduler) {
     return numPerformSlots(scheduler) > 0 ? 'succeed' : 'drop';
@@ -39,16 +41,14 @@ export const dropQueuedTasksPolicy = {
 
 export const cancelOngoingTasksPolicy = {
   cancelReason: `it belongs to a 'restartable' Task that was .perform()ed again`,
-  schedule(scheduler) {
+  schedule(maxConcurrency, queuedTaskInstances, activeTaskInstances) {
     // [a,b,_] [c,d,e,f] becomes
     // [d,e,f] []
-    let activeTaskInstances = scheduler.activeTaskInstances;
-    let queuedTaskInstances = scheduler.queuedTaskInstances;
     activeTaskInstances.push(...queuedTaskInstances);
     queuedTaskInstances.length = 0;
 
-    let numToShift = Math.max(0, activeTaskInstances.length - scheduler.maxConcurrency);
-    scheduler.spliceTaskInstances(this.cancelReason, activeTaskInstances, 0, numToShift);
+    let numToShift = Math.max(0, activeTaskInstances.length - maxConcurrency);
+    spliceTaskInstances(this.cancelReason, activeTaskInstances, 0, numToShift);
   },
   getNextPerformStatus(scheduler) {
     return numPerformSlots(scheduler) > 0 ? 'succeed' : 'cancel_previous';
@@ -57,11 +57,11 @@ export const cancelOngoingTasksPolicy = {
 
 export const dropButKeepLatestPolicy = {
   cancelReason: `it belongs to a 'keepLatest' Task that was already running`,
-  schedule(scheduler) {
+  schedule(maxConcurrency, queuedTaskInstances, activeTaskInstances) {
     // [a,b,_] [c,d,e,f] becomes
     // [d,e,f] []
-    saturateActiveQueue(scheduler);
-    scheduler.spliceTaskInstances(this.cancelReason, scheduler.queuedTaskInstances, 0, scheduler.queuedTaskInstances.length - 1);
+    saturateActiveQueue(maxConcurrency, queuedTaskInstances, activeTaskInstances);
+    spliceTaskInstances(this.cancelReason, queuedTaskInstances, 0, queuedTaskInstances.length - 1);
   }
 };
 

--- a/addon/-property-modifiers-mixin.js
+++ b/addon/-property-modifiers-mixin.js
@@ -15,6 +15,13 @@ export const propertyModifiers = {
   _hasUsedModifier: false,
   _hasSetBufferPolicy: false,
 
+  _channelFunc: () => '',
+
+  channel(func){
+    this._channelFunc = func;
+    return this;
+  },
+
   restartable() {
     return setBufferPolicy(this, cancelOngoingTasksPolicy);
   },
@@ -74,6 +81,7 @@ export function resolveScheduler(propertyObj, obj, TaskGroup) {
     return taskGroup._scheduler;
   } else {
     return Scheduler.create({
+      channelFunc: propertyObj._channelFunc,
       bufferPolicy: propertyObj._bufferPolicy,
       maxConcurrency: propertyObj._maxConcurrency
     });

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -320,7 +320,7 @@ export const Task = Ember.Object.extend(TaskStateMixin, {
       taskInstance.cancel();
     }
 
-    this._scheduler.schedule(taskInstance);
+    this._scheduler.schedule(taskInstance, args);
     return taskInstance;
   },
 

--- a/testem.json
+++ b/testem.json
@@ -9,5 +9,6 @@
   "launch_in_dev": [
     "PhantomJS",
     "Chrome"
-  ]
+  ],
+  "parallel": 2
 }

--- a/tests/unit/buffering-test.js
+++ b/tests/unit/buffering-test.js
@@ -28,21 +28,22 @@ let sporadicObservable = Observable.concat(
 module('Unit: buffering');
 
 function doBufferingTest(description, observable, bufferPolicyFn, expectations, maxConcurrency) {
-  test(description, function(assert) {
+  test(description, function (assert) {
     let start = assert.async();
     assert.expect(2);
 
-    let last = expectations[expectations.length-1];
+    let last = expectations[expectations.length - 1];
 
     let sem = 0;
     let maxSem = 0;
+
     function bumpSemaphore(inc) {
       sem = sem + inc;
       maxSem = Math.max(maxSem, sem);
     }
 
     let arr = [];
-    let taskCP = task(function * (v) {
+    let taskCP = task(function *(v) {
       try {
         bumpSemaphore(+1);
         yield timeout(10);
@@ -75,6 +76,9 @@ function doBufferingTest(description, observable, bufferPolicyFn, expectations, 
     });
   });
 }
+
+//doBufferingTest("channel: two", range(1, 10), (t) => t.channel(arg=>arg > 2 ? '1' : '2').maxConcurrency(1),
+//  [1,2,3,4,5,101,102,103,104,105], 1);
 
 doBufferingTest("default buffering: ranges",   rangeObservable,    (t) => t, [1,2,3,4,5,101,102,103,104,105], 5);
 doBufferingTest("default buffering: sporadic", sporadicObservable, (t) => t, [1,2,3,4,5,6], 3);


### PR DESCRIPTION
Ref #162 

This is an initial stab at implementing multiple 'channels' per given task. It's no where near done, but I figured I would try and see if it was possible - and it seems so. The code is a super proof of concept and is a bit nasty (i'm looking at you `taskInstancesByChannel`).

Each task has a 'channel', which is just a string key returned from a user-defined function based on the tasks arguments, e.g:

```js
thing: task(function*(name){ 
      yield timeout(100); 
      console.log(name);
}).channel(name=>name).drop()
```

Each time `thing` is performed the arguments would be passed to the function given to channel, which must return a string. The buffer policies for the task perform the same, but only apply **to the subset of tasks with the same channel identifier**.

So, in theory, the `thing` task could have two concurrently executing tasks with different channel identifiers, `tom` and `henry`. If another task is performed (e.g `thing.perform('tom')`), then the `drop` would kick in and the task would not execute. However `thing.perform('james')` would execute concurrently with `tom` and `henry`.

I implemented this by separating the buffer policies from the scheduler. Instead of passing in the scheduler instance to the buffer policies we pass in arrays of queued/active task instances, which allows the scheduler to pass a given subset in.

Please tear this merge request apart and let me know if it's worth exploring in more detail, if so I will invest some more time into it.