### PR TITLE
Enhance waitForProperty to allow passing in value to match against

### DIFF
--- a/addon/-wait-for.js
+++ b/addon/-wait-for.js
@@ -58,10 +58,15 @@ class WaitForEventYieldable {
 }
 
 class WaitForPropertyYieldable {
-  constructor(object, key, predicateCallback) {
+  constructor(object, key, predicateCallback = Boolean) {
     this.object = object;
     this.key = key;
-    this.predicateCallback = predicateCallback || Boolean;
+
+    if (typeof predicateCallback === 'function') {
+      this.predicateCallback = predicateCallback;
+    } else {
+      this.predicateCallback = (v) => v === predicateCallback;
+    }
   }
 
   [yieldableSymbol](taskInstance, resumeIndex) {


### PR DESCRIPTION
Prior to this commit, if you wanted to wait for
a property to equal a certain value, you had to
pass in something like `(v) => v === expectedValue`
as the third arg. With this commit, you can just
pass in `expectedValue` (so long as it isn't
a function) and it'll automatically create the
predicate function for you.

So instead of

```
yield waitForProperty(this, 'foo', (v) => v === 3);
```

you can just do

```
yield waitForProperty(this, 'foo', 3);
```