### PR TITLE
Add a testimonials page

### DIFF
--- a/tests/dummy/app/components/testimonial-box/component.js
+++ b/tests/dummy/app/components/testimonial-box/component.js
@@ -1,0 +1,11 @@
+import Component from '@ember/component';
+
+export default Component.extend({
+  classNames: ['testimonial-box'],
+  attributeBindings: ['role'],
+  role: 'button',
+
+  click() {
+    return this.get('onClick')(this.get('testimonial'));
+  }
+});

--- a/tests/dummy/app/components/testimonial-box/template.hbs
+++ b/tests/dummy/app/components/testimonial-box/template.hbs
@@ -1,0 +1,21 @@
+<div class="testimonial-header">
+  <span class="testimonial-title">
+    {{testimonial.title}}
+  </span>
+</div>
+
+<p class="testimonial-byline">
+  <span class="testimonial-author">
+    By {{testimonial.author}}
+  </span>
+  <time class="testimonial-date" datetime={{testimonial.date}}>
+    {{testimonial.relativeDate}}
+  </time>
+</p>
+
+<div class="testimonial-content">
+  {{testimonial.excerpt}}
+  {{#if testimonial.hasMore}}
+    <p><a>Read more</a></p>
+  {{/if}}
+</div>

--- a/tests/dummy/app/docs/template.hbs
+++ b/tests/dummy/app/docs/template.hbs
@@ -2,6 +2,9 @@
   <div class="docs row">
     <div class="three columns">
       <div class="side-menu">
+        <div class="toc-entry">
+          {{#link-to "docs.testimonials"}}Testimonials{{/link-to}}
+        </div>
         {{#each tableOfContents as |entry|}}
           {{#if entry.section}}
             <div class="toc-section-title">
@@ -34,7 +37,7 @@
 
       {{outlet}}
 
-      <br> <br> <br> <br> 
+      <br> <br> <br> <br>
 
       {{nav-header nextTopic=nextTopic prevTopic=prevTopic}}
     </div>

--- a/tests/dummy/app/docs/testimonials/index/controller.js
+++ b/tests/dummy/app/docs/testimonials/index/controller.js
@@ -1,0 +1,36 @@
+import Controller from '@ember/controller';
+import { computed } from '@ember/object';
+import { or, reads } from '@ember/object/computed';
+import { inject as service } from '@ember/service';
+
+export default Controller.extend({
+  testimonialApi: service(),
+
+  queryParams: ['page'],
+  page: 1,
+
+  error: reads('model.currentTaskInstance.error'),
+  isLoading: reads('model.currentTaskInstance.isRunning'),
+  testimonials: or('model.{currentTaskInstance,previousTaskInstance}.value.testimonials'),
+  pagination: or('model.{currentTaskInstance,previousTaskInstance}.value.pagination'),
+
+  previousPage: computed('pagination.{previous_url,page}', {
+    get() {
+      if (!this.get('pagination.previous_url')) { return; }
+      return this.get('pagination.page') - 1;
+    }
+  }),
+
+  nextPage: computed('pagination.{next_url,page}', {
+    get() {
+      if (!this.get('pagination.next_url')) { return; }
+      return this.get('pagination.page') + 1;
+    }
+  }),
+
+  actions: {
+    showTestimonial(testimonial) {
+      return this.transitionToRoute('docs.testimonials.show', testimonial);
+    }
+  }
+});

--- a/tests/dummy/app/docs/testimonials/index/route.js
+++ b/tests/dummy/app/docs/testimonials/index/route.js
@@ -1,0 +1,47 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { Promise } from 'rsvp';
+import { all, task, timeout } from 'ember-concurrency';
+import TestimonialProxy from 'dummy/testimonial-proxy';
+
+// Sometimes the loading of the API is too fast.
+const ARTIFICIAL_NETWORK_DELAY = 700;
+
+export default Route.extend({
+  fastboot: service(),
+  testimonialApi: service(),
+
+  queryParams: {
+    page: { refreshModel: true }
+  },
+
+  model(params) {
+    let previousTaskInstance = this.get('fetchTestimonials.lastSuccessful');
+    let currentTaskInstance = this.get('fetchTestimonials').perform(params);
+    // Prevent unhandled bubbling; error handled in the template
+    currentTaskInstance.catch(() => {});
+    return { previousTaskInstance, currentTaskInstance };
+  },
+
+  fetchTestimonials: task(function* (params) {
+    yield this.waitInFastBoot();
+    let endPoint = params.page === 1
+      ? 'testimonials.json'
+      : `testimonials-${params.page}.json`;
+    let req = this.get('testimonialApi').request(endPoint);
+    let [ results ] = yield all([req, timeout(ARTIFICIAL_NETWORK_DELAY)]);
+    results.testimonials = results.testimonials.map(data => {
+      return TestimonialProxy.build(data.testimonial);
+    });
+    return results;
+  })
+  .drop()
+  .cancelOn('deactivate'),
+
+  waitInFastBoot() {
+    if (this.get('fastboot.isFastBoot')) {
+      // Wait forever in FastBoot
+      return new Promise(() => {});
+    }
+  }
+});

--- a/tests/dummy/app/docs/testimonials/index/template.hbs
+++ b/tests/dummy/app/docs/testimonials/index/template.hbs
@@ -1,0 +1,70 @@
+<h2>Testimonials</h2>
+
+<div class="row">
+  <a href={{testimonialApi.createUrl}} class="button">
+    Create New Testimonial
+  </a>
+</div>
+
+<div class="row">
+  {{#if previousPage}}
+    <p class="u-pull-left">
+      {{#link-to "docs.testimonials" (query-params page=previousPage)}}
+        &lt; Previous
+      {{/link-to}}
+    </p>
+  {{/if}}
+
+  {{#if nextPage}}
+    <p class="u-pull-right">
+      {{#link-to "docs.testimonials" (query-params page=nextPage)}}
+        Next &gt;
+      {{/link-to}}
+    </p>
+  {{/if}}
+</div>
+
+<div class="row">
+  {{#if isLoading}}
+    <div class="u-full-width centered">
+      Loading more testimonials&hellip; {{loading-spinner}}
+    </div>
+  {{/if}}
+
+  {{#if error}}
+    <div class="u-full-width centered">
+      {{error}}
+    </div>
+  {{/if}}
+</div>
+
+<div class="row">
+  {{#each testimonials as |testimonial|}}
+    {{testimonial-box
+        class="u-full-width"
+        testimonial=testimonial
+        onClick=(action "showTestimonial" testimonial)}}
+  {{else unless isLoading}}
+    <div class="u-full-width centered">
+      Be the first to <a href={{testimonialApi.createUrl}}>add a testimonial</a>.
+    </div>
+  {{/each}}
+</div>
+
+<div class="row">
+  {{#if previousPage}}
+    <p class="u-pull-left">
+      {{#link-to "docs.testimonials" (query-params page=previousPage)}}
+        &lt; Previous
+      {{/link-to}}
+    </p>
+  {{/if}}
+
+  {{#if nextPage}}
+    <p class="u-pull-right">
+      {{#link-to "docs.testimonials" (query-params page=nextPage)}}
+        Next &gt;
+      {{/link-to}}
+    </p>
+  {{/if}}
+</div>

--- a/tests/dummy/app/docs/testimonials/show/controller.js
+++ b/tests/dummy/app/docs/testimonials/show/controller.js
@@ -1,0 +1,6 @@
+import Controller from '@ember/controller';
+import { reads } from '@ember/object/computed';
+
+export default Controller.extend({
+  testimonial: reads('model')
+});

--- a/tests/dummy/app/docs/testimonials/show/route.js
+++ b/tests/dummy/app/docs/testimonials/show/route.js
@@ -1,0 +1,20 @@
+import Route from '@ember/routing/route';
+import { inject as service } from '@ember/service';
+import { task } from 'ember-concurrency';
+import TestimonialProxy from 'dummy/testimonial-proxy';
+
+export default Route.extend({
+  testimonialApi: service(),
+
+  model(params) {
+    return this.get('fetchModel').perform(params);
+  },
+
+  fetchModel: task(function* (params) {
+    const testimonialApi = this.get('testimonialApi');
+    let data = yield testimonialApi.request(`testimonials/${params.slug}.json`);
+    return TestimonialProxy.build(data.testimonial);
+  })
+  .drop()
+  .cancelOn('deactivate')
+});

--- a/tests/dummy/app/docs/testimonials/show/template.hbs
+++ b/tests/dummy/app/docs/testimonials/show/template.hbs
@@ -1,0 +1,19 @@
+<h2>{{testimonial.title}}</h2>
+
+<div class="byline">
+  <span class="author">
+    By
+    {{#if testimonial.link}}
+      <a href={{testimonial.link}}>{{testimonial.author}}</a>
+    {{else}}
+      {{testimonial.author}}
+    {{/if}}
+  </span>
+  <time class="date" datetime={{testimonial.date}}>
+    {{testimonial.relativeDate}}
+  </time>
+</div>
+
+<div class="content">
+  {{testimonial.rendered}}
+</div>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,9 @@ Router.map(function() {
   this.route('docs', function() {
     this.route('introduction');
     this.route('installation');
+    this.route('testimonials', function() {
+      this.route('show', { path: ':slug' });
+    });
     this.route('writing-tasks');
 
     this.route('tutorial', function() {

--- a/tests/dummy/app/services/testimonial-api.js
+++ b/tests/dummy/app/services/testimonial-api.js
@@ -1,0 +1,7 @@
+import AjaxService from 'ember-ajax/services/ajax';
+import config from 'dummy/config/environment';
+
+export default AjaxService.extend({
+  host: config.APP.testimonialEndpoint,
+  createUrl: config.APP.createTestimonialUrl
+});

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -227,3 +227,34 @@ th, td {
 .loading-spinner {
   display: inline-block;
 }
+
+.testimonial-box {
+  border-radius: 8px;
+  border: 1px solid #000;
+  cursor: pointer;
+  margin: 10px auto;
+  padding: 10px;
+  text-align: center;
+  transition: box-shadow 0.2s ease;
+  width: 80%;
+
+  .testimonial-header {
+    font-size: 1.4em;
+  }
+
+  .testimonial-byline {
+    font-size: 0.8em;
+  }
+
+  .testimonial-content p:last-child {
+    margin-bottom: 0;
+  }
+
+  &:hover {
+    box-shadow: 4px 4px 4px #ccc;
+  }
+
+  &:active {
+    box-shadow: none;
+  }
+}

--- a/tests/dummy/app/testimonial-proxy.js
+++ b/tests/dummy/app/testimonial-proxy.js
@@ -1,0 +1,71 @@
+import ObjectProxy from '@ember/object/proxy';
+import { computed } from '@ember/object';
+import { htmlSafe } from '@ember/string';
+const { ceil, floor } = Math;
+
+// Algorithm from https://stackoverflow.com/a/7641822/227176
+function prettyDate(isoTime) {
+  let date = new Date(isoTime);
+  let diff = (((new Date()).getTime() - date.getTime()) / 1000);
+  let dayDiff = floor(diff / 86400);
+  let year = date.getFullYear();
+  let month = date.getMonth() + 1;
+  let day = date.getDate();
+
+  if (isNaN(dayDiff) || dayDiff < 0 || dayDiff >= 31) {
+    let yearStr = `${year}`;
+    let monthStr = `00${month}`.substr(-2);
+    let dayStr = `00${day}`.substr(-2);
+    return `${yearStr}-${monthStr}-${dayStr}`;
+  }
+
+  if (dayDiff === 0) {
+    if (diff < 60) { return 'just now'; }
+    if (diff < 120) { return '1 minute ago'; }
+    if (diff < 3600) { return `${floor(diff / 60)} minutes ago`; }
+    if (diff < 7200) { return '1 hour ago'; }
+    return `${floor(diff / 3600)} hours ago`;
+  }
+
+  if (dayDiff === 1) { return 'Yesterday'; }
+  if (dayDiff < 7) { return `${dayDiff} days ago`; }
+  return `${ceil(dayDiff / 7)} weeks ago`;
+}
+
+const TestimonialProxy = ObjectProxy.extend({
+  relativeDate: computed('content.date', {
+    get() {
+      return prettyDate(this.get('content.date'));
+    }
+  }),
+
+  rendered: computed('content.rendered', {
+    get() {
+      return htmlSafe(this.get('content.rendered'));
+    }
+  }),
+
+  excerpt: computed('content.excerpt', {
+    get() {
+      return htmlSafe(this.get('content.excerpt'));
+    }
+  }),
+
+  hasMore: computed('content.{excerpt,rendered}', {
+    get() {
+      let excerpt = this.get('content.excerpt') || '';
+      let rendered = this.get('content.rendered') || '';
+      return excerpt.length < rendered.length;
+    }
+  })
+});
+
+TestimonialProxy.reopenClass({
+  build(content) {
+    let testimonial = TestimonialProxy.create({ content });
+    testimonial.slug = content.slug;
+    return testimonial;
+  }
+});
+
+export default TestimonialProxy;

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -20,6 +20,8 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+      testimonialEndpoint: 'https://sukima.github.io/ember-concurrency-testimonials-api',
+      createTestimonialUrl: 'https://github.com/sukima/ember-concurrency-testimonials-api/tree/master#how-to-contribute'
     },
 
     fastboot: {


### PR DESCRIPTION
This is a page that will list user testimonials. The intent is to offer collaboration with the community by giving them a platform to posts stories where ember-concurrency has really helped.

To accomplish both the presentation and the ability for users to contribute through Pull Requests this uses a [3rd party API](https://github.com/sukima/ember-concurrency-testimonials-api/tree/master#how-to-contribute). This API is simply a GitHub page with static JSON files. They are created by parsing Markdown documents. This is possible because GitHub adds CORS headers for files served through GitHub Pages.

A user will contribute by creating a Markdown document (with some YAML front matter) like they would with a static Jekyll site. The build tools will convert them to JSON files and push to `gh-pages`. The static files act as a live API which this feature uses to populate its model(s).

Currently the API has a bunch of dummy data. This will change when this is released. The feature can handle an empty result set with a _Be the first_ message.

## Requirements Needed

- [ ] Who should own the static API repository?
- [ ] The API has knowledge of the number of total testimonials. Do we want to show these numbers in the template?
- [ ] Do we want to pre-fill some testimonials before initial launch?
- [ ] When a user clicks create new they are redirected to the API repo README; how do we want to word the contributions instructions?

## Demo

https://sandbox.tritarget.org/docs/testimonials

![ec-testimonials](https://user-images.githubusercontent.com/70075/37238261-8dde60c6-23f0-11e8-8719-d9e3cd734ac9.gif)