### PR TITLE
Introduce tagged timers to help test timer loops and long timers

### DIFF
--- a/addon/-timeout.js
+++ b/addon/-timeout.js
@@ -1,0 +1,31 @@
+import {Promise} from 'rsvp';
+import {later, cancel} from '@ember/runloop';
+import {yieldableSymbol, YIELDABLE_CONTINUE} from './yieldables';
+
+export class TimeoutPromise {
+  constructor(ms) {
+    this.ms = ms;
+  }
+
+  then() {
+    let timerId;
+    let promise = new Promise(r => {
+      timerId = later(() => {
+        r();
+      }, this.ms);
+    });
+    promise.__ec_cancel__ = () => {
+      cancel(timerId);
+    };
+    return promise;
+  }
+
+  [yieldableSymbol](taskInstance, resumeIndex) {
+    let timerId = later(() => {
+      taskInstance.proceed(resumeIndex, YIELDABLE_CONTINUE, null);
+    }, this.ms);
+    return () => {
+      cancel(timerId);
+    };
+  }
+}

--- a/addon/testing.js
+++ b/addon/testing.js
@@ -1,0 +1,73 @@
+import {get} from '@ember/object';
+import {yieldableSymbol, YIELDABLE_CONTINUE} from './yieldables';
+import {TimeoutPromise} from './-timeout';
+
+let TEST_TIMERS = {};
+let TIMES_SINCE_LAST_CLEAN = 0;
+
+function cleanupTestTimers() {
+  let newTestTimers = {};
+  for (let k in TEST_TIMERS) {
+    let timers = TEST_TIMERS[k];
+
+    newTestTimers[k] = [];
+
+    timers.forEach(timer => {
+      // assume task instances from previous test runs have been properly canceled
+      if (get(timer.taskInstance, 'isRunning')) {
+        newTestTimers[k].pushk(timer);
+      }
+    });
+  }
+  TEST_TIMERS = newTestTimers;
+}
+
+export class TestTimeoutPromise extends TimeoutPromise {
+  constructor(ms, label) {
+    super(ms);
+    this.label = label;
+  }
+
+  [yieldableSymbol](taskInstance, resumeIndex) {
+    if (TIMES_SINCE_LAST_CLEAN++ > 20) {
+      TIMES_SINCE_LAST_CLEAN = 0;
+      cleanupTestTimers();
+    }
+
+    let intervalId;
+    let label = this.label;
+    TEST_TIMERS[label] = TEST_TIMERS[label] || [];
+    TEST_TIMERS[label].push({
+      label,
+      taskInstance,
+      hasResumed: false,
+      resume() {
+        if (this.hasResumed) {
+          return;
+        }
+        this.hasResumed = true;
+        taskInstance.proceed(resumeIndex, YIELDABLE_CONTINUE, null);
+      },
+    });
+
+    return () => {
+      if (intervalId) {
+        clearInterval(intervalId);
+      }
+    };
+  }
+}
+
+export function resumeTimers(label) {
+  let numResumed = 0;
+  let timers = TEST_TIMERS[label] || [];
+
+  timers.forEach(timer => {
+    if (!timer.hasResumed && get(timer.taskInstance, 'isRunning')) {
+      timer.resume();
+      numResumed++;
+    }
+  });
+
+  return numResumed;
+}

--- a/addon/yieldables.js
+++ b/addon/yieldables.js
@@ -1,0 +1,5 @@
+export const yieldableSymbol = "__ec_yieldable__";
+export const YIELDABLE_CONTINUE = "next";
+export const YIELDABLE_THROW = "throw";
+export const YIELDABLE_RETURN = "return";
+export const YIELDABLE_CANCEL = "cancel";

--- a/tests/dummy/app/testing-ergo/timer-loop/route.js
+++ b/tests/dummy/app/testing-ergo/timer-loop/route.js
@@ -8,7 +8,7 @@ export default Route.extend({
   loopingTask: task(function * () {
     while(true) {
       this.controller.incrementProperty('foo');
-      yield timeout(200);
+      yield timeout(200, 'test-tag');
     }
   }),
 });

--- a/tests/unit/timeout-test.js
+++ b/tests/unit/timeout-test.js
@@ -1,0 +1,32 @@
+import { defer } from 'rsvp';
+import { A } from '@ember/array';
+import Evented from '@ember/object/evented';
+import { run, later } from '@ember/runloop';
+import EmberObject, { computed } from '@ember/object';
+import Ember from 'ember';
+import { task, timeout } from 'ember-concurrency';
+import { module, test } from 'qunit';
+
+module('Unit: timeouts', function() {
+  test("works with tagged timers", function(assert) {
+    assert.expect(3);
+
+    let Obj = EmberObject.extend({
+      timerLoop: task(function * () {
+        while(true) {
+          // yield timeout(5000, 'my-tag');
+          debugger;
+          yield timeout(5000);
+        }
+      })
+    });
+
+    let taskInstance;
+    run(() => {
+      taskInstance = Obj.create().get('timerLoop').perform();
+    });
+
+    assert.ok(taskInstance.get('isRunning'));
+  });
+});
+


### PR DESCRIPTION
Example: the following snippet has a timer loop that will
indefinitely pause your test suite (because ember-testing
internally tries to wait for all timers to elapse before
considering the app as "settled"):

```
  loopingTask: task(function * () {
    while(true) {
      // doStuff()
      yield timeout(200);
    }
  }),
```

To aid in these cases (and other cases with long timers) you
can now pass a second param into `timeout()` which is a test tag:

```
  numIterations: 0,
  loopingTask: task(function * () {
    while(true) {
      this.incrementProperty('numIterations');
      yield timeout(200, 'server-poll-timer');
    }
  }),
```

When testing, a `timeout()` with a test tag will indefinitely
pause the task at the `yield timeout(...)` without causing
ember-testing to stop execution of your test. From within
a test, you can use the new `resumeTimers()` utility method
to resume any timers with a matching test tag. `resumeTimers(testTag)`
returns the number of matching timers that were resumed (so you
can assert that the task was paused at the timer where you expected).

Timer tags allow you to step through timer loops one iteration at
a time without indefinitely pausing or even slowing down your test suite:

```
  test('polling loop works', async function(assert) {
    await visit('/route-with-timer-loop');

    assert.equal($('.num-iterations').text(), '1');
    assert.equal(await resumeTimers('server-poll-timer'), 1);

    assert.equal($('.num-iterations').text(), '2');
    assert.equal(await resumeTimers('server-poll-timer'), 1);

    assert.equal($('.num-iterations').text(), '3');
  });
```