### PR TITLE
Fix link to task cancellation help page

### DIFF
--- a/addon/-task-instance.js
+++ b/addon/-task-instance.js
@@ -261,7 +261,7 @@ let taskInstanceAttrs = {
     set(this, 'isCanceling', true);
 
     let name = get(this, 'task._propertyName') || "<unknown>";
-    set(this, 'cancelReason', `TaskInstance '${name}' was canceled because ${cancelReason}. For more information, see: http://ember-concurrency.com/#/docs/task-cancelation-help`);
+    set(this, 'cancelReason', `TaskInstance '${name}' was canceled because ${cancelReason}. For more information, see: http://ember-concurrency.com/docs/task-cancelation-help`);
 
     if (this.hasStarted) {
       this._proceedSoon(YIELDABLE_CANCEL, null);


### PR DESCRIPTION
The page no longer uses `#` routing.