### PR TITLE
fix: Add evented modifier to evented documentation and use Evented mixin in the example as well

### DIFF
--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -601,10 +601,12 @@ objectAssign(TaskProperty.prototype, propertyModifiers, {
    * changes.
    *
    * ```js
-   * export default Component.extend({
+   * import Evented from '@ember/object/evented';
+   *
+   * export default Component.extend(Evented, {
    *   uploadTask: task(function* (file) {
    *     // ... file upload stuff
-   *   }).drop(),
+   *   }).evented(),
    *
    *   uploadedStarted: on('uploadTask:started', function(taskInstance) {
    *     this.get('analytics').track("User Photo: upload started");

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -601,9 +601,8 @@ objectAssign(TaskProperty.prototype, propertyModifiers, {
    * changes.
    *
    * ```js
-   * import Evented from '@ember/object/evented';
    *
-   * export default Component.extend(Evented, {
+   * export default Component.extend({
    *   uploadTask: task(function* (file) {
    *     // ... file upload stuff
    *   }).evented(),


### PR DESCRIPTION
Hey @machty 

## Description

I don't have much experience with the documentation comments but it looks like the `evented` modifier documentation is using the `drop()` modifier. I added the `Evented` Mixin as well because it seems to be required.

## Question

could be possible to add something in the modifier function to add the Evented mixin to the object if it is used?

Something like: 


```js
//https://github.com/machty/ember-concurrency/blob/04226b7634d5dfa0628d64eae48b11b3e0cdbf35/addon/-property-modifiers-mixin.js#L48

 evented() {
   // not sure if there is a reliable way to check if the Mixin was mixed before 
   if (isBlank(this.trigger)) {
     this.reopen(Evented);
   }
   this._hasEnabledEvents = true;
   return this;
},


``` 

Best regards,
Daniel.