### PR TITLE
Fix ES5 getter syntax on Ember Canary

### DIFF
--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -435,11 +435,16 @@ export function TaskProperty(taskFn) {
   this._observes = null;
 }
 
+const superSetup = _ComputedProperty.prototype.setup;
 TaskProperty.prototype = Object.create(_ComputedProperty.prototype);
 objectAssign(TaskProperty.prototype, propertyModifiers, {
   constructor: TaskProperty,
 
   setup(proto, taskName) {
+    if (superSetup) {
+      superSetup.call(this, proto, taskName);
+    }
+
     if (this._maxConcurrency !== Infinity && !this._hasSetBufferPolicy) {
       Ember.Logger.warn(`The use of maxConcurrency() without a specified task modifier is deprecated and won't be supported in future versions of ember-concurrency. Please specify a task modifier instead, e.g. \`${taskName}: task(...).enqueue().maxConcurrency(${this._maxConcurrency})\``);
     }

--- a/tests/unit/task-test.js
+++ b/tests/unit/task-test.js
@@ -564,4 +564,25 @@ module('Unit: task', function(hooks) {
       ]
     ]);
   });
+
+  test("ES5 getter syntax works", function(assert) {
+    let Obj = EmberObject.extend({
+      es5getterSyntaxSupported: computed(function() {
+        return "yes";
+      }),
+      task: task(function * () {
+        assert.ok(true);
+      }),
+    });
+
+    run(() => {
+      let obj = Obj.create();
+      if (obj.es5getterSyntaxSupported === 'yes') {
+        assert.expect(1);
+        obj.task.perform();
+      } else {
+        assert.expect(0);
+      }
+    });
+  });
 });


### PR DESCRIPTION
Root cause of issue:

https://github.com/emberjs/ember.js/commit/246435e7260f45d9e5cc35a4a8b4de4f011f3625

The above commit started making use of the previously
unused Descriptor#setup method that e-c uses
for setting up observers and e-c wasn't calling
the super method, which was causing the ES5
getter to not be set on the object.

This commit calls the super `setup` method if it
exists so that Object.defineProperty is properly
called.

/cc @bendemboski