### PR TITLE
Fix task property setup

### DIFF
--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -442,7 +442,7 @@ objectAssign(TaskProperty.prototype, propertyModifiers, {
 
   setup(proto, taskName) {
     if (superSetup) {
-      superSetup.call(this, proto, taskName);
+      superSetup.call(this, ...arguments);
     }
 
     if (this._maxConcurrency !== Infinity && !this._hasSetBufferPolicy) {


### PR DESCRIPTION
https://github.com/emberjs/ember.js/commit/be9552f29a329f3b98f1651a075a49f3ed2c92c6#diff-dd4157e0e33abf6659566beab2bee2f2 caused task properties to start failing to setup because they were not passing the (new) third argument to the super call. Use ...arguments to fix this.