### PR TITLE
cancelAll({ resetState: true }) can remove existing derived state

### DIFF
--- a/addon/-scheduler.js
+++ b/addon/-scheduler.js
@@ -23,7 +23,7 @@ const Scheduler = EmberObject.extend({
     this.queuedTaskInstances = [];
   },
 
-  cancelAll(reason) {
+  cancelAll({ reason }) {
     let seen = [];
     this.spliceTaskInstances(reason, this.activeTaskInstances, 0, this.activeTaskInstances.length, seen);
     this.spliceTaskInstances(reason, this.queuedTaskInstances, 0, this.queuedTaskInstances.length, seen);

--- a/addon/-scheduler.js
+++ b/addon/-scheduler.js
@@ -23,7 +23,7 @@ const Scheduler = EmberObject.extend({
     this.queuedTaskInstances = [];
   },
 
-  cancelAll({ reason }) {
+  cancelAll(reason) {
     let seen = [];
     this.spliceTaskInstances(reason, this.activeTaskInstances, 0, this.activeTaskInstances.length, seen);
     this.spliceTaskInstances(reason, this.queuedTaskInstances, 0, this.queuedTaskInstances.length, seen);

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -187,7 +187,7 @@ export const Task = EmberObject.extend(TaskStateMixin, {
       this._taskInstanceFactory = EncapsulatedTask.extend(ownerInjection, this.fn);
     }
 
-    _cleanupOnDestroy(this.context, this, 'cancelAll', 'the object it lives on was destroyed or unrendered');
+    _cleanupOnDestroy(this.context, this, 'cancelAll', { reason: 'the object it lives on was destroyed or unrendered' });
   },
 
   _curry(...args) {

--- a/addon/-task-state-mixin.js
+++ b/addon/-task-state-mixin.js
@@ -47,14 +47,7 @@ export default Mixin.create({
     this._scheduler.cancelAll({ reason });
 
     if (resetState) {
-      this.setProperties({
-        'last': null,
-        'lastRunning': null,
-        'lastPerformed': null,
-        'lastSuccessful': null,
-        'lastComplete': null,
-        'performCount': 0,
-      });
+      this._resetState();
     }
   },
 
@@ -64,5 +57,15 @@ export default Mixin.create({
 
   _scheduler: null,
 
+  _resetState() {
+    this.setProperties({
+      'last': null,
+      'lastRunning': null,
+      'lastPerformed': null,
+      'lastSuccessful': null,
+      'lastComplete': null,
+      'performCount': 0,
+    });
+  },
 });
 

--- a/addon/-task-state-mixin.js
+++ b/addon/-task-state-mixin.js
@@ -46,7 +46,16 @@ export default Mixin.create({
 
     this._scheduler.cancelAll({ reason });
 
-    if (resetState) { this.set('_scheduler', null); }
+    if (resetState) {
+      this.setProperties({
+        'last': null,
+        'lastRunning': null,
+        'lastPerformed': null,
+        'lastSuccessful': null,
+        'lastComplete': null,
+        'performCount': 0,
+      });
+    }
   },
 
   group: computed(function() {

--- a/addon/-task-state-mixin.js
+++ b/addon/-task-state-mixin.js
@@ -64,6 +64,9 @@ export default Mixin.create({
       'lastPerformed': null,
       'lastSuccessful': null,
       'lastComplete': null,
+      'lastErrored': null,
+      'lastCanceled': null,
+      'lastIncomplete': null,
       'performCount': 0,
     });
   },

--- a/addon/-task-state-mixin.js
+++ b/addon/-task-state-mixin.js
@@ -40,8 +40,13 @@ export default Mixin.create({
   numQueued: 0,
   _seenIndex: 0,
 
-  cancelAll(reason = ".cancelAll() was explicitly called on the Task") {
-    this._scheduler.cancelAll(reason);
+  cancelAll(options) {
+    let { reason, resetState } = options || {};
+    reason = reason || ".cancelAll() was explicitly called on the Task";
+
+    this._scheduler.cancelAll({ reason });
+
+    if (resetState) { this.set('_scheduler', null); }
   },
 
   group: computed(function() {

--- a/addon/-task-state-mixin.js
+++ b/addon/-task-state-mixin.js
@@ -44,7 +44,7 @@ export default Mixin.create({
     let { reason, resetState } = options || {};
     reason = reason || ".cancelAll() was explicitly called on the Task";
 
-    this._scheduler.cancelAll({ reason });
+    this._scheduler.cancelAll(reason);
 
     if (resetState) {
       this._resetState();

--- a/addon/helpers/cancel-all.js
+++ b/addon/helpers/cancel-all.js
@@ -10,7 +10,7 @@ export function cancelHelper(args) {
     assert(`The first argument passed to the \`cancel-all\` helper should be a Task or TaskGroup (without quotes); you passed ${cancelable}`, false);
   }
 
-  return taskHelperClosure('cancel-all', 'cancelAll', [cancelable, CANCEL_REASON]);
+  return taskHelperClosure('cancel-all', 'cancelAll', [cancelable, { reason: CANCEL_REASON }]);
 }
 
 export default helper(cancelHelper);


### PR DESCRIPTION
This is a first attempt at https://github.com/machty/ember-concurrency/issues/243.

This change includes two changes:

1. Change the signature of `cancelAll(reason)` to `cancelAll({ reason })`

   It was stated in https://github.com/machty/ember-concurrency/issues/243#issuecomment-424844648 that it would probably be ok to change this without backwards compatibility. However, if there's a desire to have backwards compatibility, it wouldn't be hard to add.

   Also note that I changed this signature for both the `cancelAll` on the scheduler as well as the task property. It isn't actually necessary to change the signature on the scheduler, but it seemed worth being consistent there. Again, let me know if you have a strong opinion :man_shrugging: 

2. Add a `resetState` option to `taskProperty.cancelAll`

   Currently, this explicitly sets state attributes to `null`, effectively throwing away any existing state. I have almost no understanding of the internals of ember-concurrency, so I have no idea what consequences this might have. Please review and let me know if there might be a better approach to take here.