### PR TITLE
Update readme for more accuracy

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ This project uses `yarn` as a package manager. If you're adding a new dependency
 
 * `git clone` this repository
 * `yarn install`
-* `bower install`
 
 ### Running
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ This project uses `yarn` as a package manager. If you're adding a new dependency
 
 ### Running Tests
 
-* `yarn test` (Runs `ember try:each` to test your addon against multiple Ember versions)
+* `yarn test:all` (Runs `ember try:each` to test your addon against multiple Ember versions)
 * `ember test`
 * `ember test --server`
 


### PR DESCRIPTION
As I started working on #253, I noticed a few things in the README that didn't seem right. Here are a couple of random updates the README for things that I noticed.


* Remove `bower install`

  It looks like `bower.json` was removed in 554e5c48bdf883f53e2792fe22aaef79282b2f71. It doesn't make sense to instruct potential maintainers to run `bower install`.

  This was clearly something from the original blueprint that was missed when removing jQuery/bower. I think most maintainers know what to do but it's nice to have the README be more accurate to prevent confusion for a newer contributor.

* Update the running tests section

  Running `yarn test` did not run `ember try:each`, as stated, so I updated the example. Is there an opinion as to which way potential contributors should be running tests? I'm happy to change this if there's an opinion. Otherwise this change simply makes the README more accurate.
