### PR TITLE
Use correct task name in snippets

### DIFF
--- a/tests/dummy/snippets/task-cancelation-example-1.js
+++ b/tests/dummy/snippets/task-cancelation-example-1.js
@@ -7,7 +7,7 @@ export default Component.extend({
 
   actions: {
     fetchResults() {
-      this.get('doStuff').perform().then((results) => {
+      this.get('queryServer').perform().then((results) => {
         this.set('results', results);
       });
     }

--- a/tests/dummy/snippets/task-cancelation-example-2.js
+++ b/tests/dummy/snippets/task-cancelation-example-2.js
@@ -9,7 +9,7 @@ export default Component.extend({
 
   actions: {
     fetchResults() {
-      this.get('doStuff').perform().then((results) => {
+      this.get('queryServer').perform().then((results) => {
         this.set('results', results);
       }).catch((e) => {
         if (!didCancel(e)) {

--- a/tests/dummy/snippets/task-cancelation-example-3.js
+++ b/tests/dummy/snippets/task-cancelation-example-3.js
@@ -6,7 +6,7 @@ export default Component.extend({
   }),
 
   fetchResults: task(function * () {
-    let results = yield this.get('doStuff').perform();
+    let results = yield this.get('queryServer').perform();
     this.set('results', results);
   }),
 });


### PR DESCRIPTION
The task name is `queryServer`, but `fetchResults` was referencing `doStuff`