### PR TITLE
moving contribution guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+This project uses `yarn` as a package manager. If you're adding a new dependency, ensure that the `yarn.lock` lockfile is updated and committed into your pull request.
+
+## Addon Maintenance
+
+### Installation
+
+* `git clone` this repository
+* `yarn install`
+
+### Running
+
+* `ember server`
+* Visit your app at http://localhost:4200.
+
+### Running Tests
+
+* `yarn test:all` (Runs `ember try:each` to test your addon against multiple Ember versions)
+* `ember test`
+* `ember test --server`
+
+### Building
+
+* `ember build`
+
+For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).
+
+### Generate Docs
+
+TODO: use build pipeline.
+
+    ./builddocs.sh
+

--- a/README.md
+++ b/README.md
@@ -35,37 +35,7 @@ approach).
 
 ## Contributing
 
-This project uses `yarn` as a package manager. If you're adding a new dependency, ensure that the `yarn.lock` lockfile is updated and committed into your pull request.
-
-## Addon Maintenance
-
-### Installation
-
-* `git clone` this repository
-* `yarn install`
-
-### Running
-
-* `ember server`
-* Visit your app at http://localhost:4200.
-
-### Running Tests
-
-* `yarn test:all` (Runs `ember try:each` to test your addon against multiple Ember versions)
-* `ember test`
-* `ember test --server`
-
-### Building
-
-* `ember build`
-
-For more information on using ember-cli, visit [http://www.ember-cli.com/](http://www.ember-cli.com/).
-
-### Generate Docs
-
-TODO: use build pipeline.
-
-    ./builddocs.sh
+See the [Contributing](CONTRIBUTING.md) guide for details.
 
 [build-status-img]: https://travis-ci.org/machty/ember-concurrency.svg?branch=master
 [build-status-link]: https://travis-ci.org/machty/ember-concurrency


### PR DESCRIPTION
This PR moves information about how to contribute away from README.md to a new CONTRIBUTING.md