### PR TITLE
Track existing task instances by their arguments

### DIFF
--- a/addon/-property-modifiers-mixin.js
+++ b/addon/-property-modifiers-mixin.js
@@ -15,6 +15,7 @@ export const propertyModifiers = {
   _hasUsedModifier: false,
   _hasSetBufferPolicy: false,
   _hasEnabledEvents: false,
+  _trackAllTaskInstances: false,
 
   restartable() {
     return setBufferPolicy(this, cancelOngoingTasksPolicy);
@@ -35,6 +36,13 @@ export const propertyModifiers = {
   maxConcurrency(n) {
     this._hasUsedModifier = true;
     this._maxConcurrency = n;
+    assertModifiersNotMixedWithGroup(this);
+    return this;
+  },
+
+  trackAllTaskInstances() {
+    this._hasUsedModifier = true;
+    this._trackAllTaskInstances = true;
     assertModifiersNotMixedWithGroup(this);
     return this;
   },
@@ -81,7 +89,8 @@ export function resolveScheduler(propertyObj, obj, TaskGroup) {
   } else {
     return Scheduler.create({
       bufferPolicy: propertyObj._bufferPolicy,
-      maxConcurrency: propertyObj._maxConcurrency
+      maxConcurrency: propertyObj._maxConcurrency,
+      trackAllTaskInstances: propertyObj._trackAllTaskInstances
     });
   }
 }


### PR DESCRIPTION
Rough implementation for increasing flexibility in finding existing task instances. Just an idea at this point and haven't tried running it, want to gauge interest.