### PR TITLE
feat: plain task invocation

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -19,7 +19,7 @@ function _computed(fn) {
       return computed(fn)(...arguments);
     };
 
-    Ember._setComputedDecorator(cp);
+    Ember._setClassicDecorator(cp);
 
     return cp;
   } else {
@@ -75,7 +75,7 @@ function _computed(fn) {
 export function task(taskFn) {
   let tp = _computed(function(_propertyName) {
     tp.taskFn.displayName = `${_propertyName} (task)`;
-    return Task.create({
+    const task = Task.create({
       fn: tp.taskFn,
       context: this,
       _origin: this,
@@ -83,8 +83,17 @@ export function task(taskFn) {
       _scheduler: resolveScheduler(tp, this, TaskGroup),
       _propertyName,
       _debug: tp._debug,
-      _hasEnabledEvents: tp._hasEnabledEvents,
+      _hasEnabledEvents: tp._hasEnabledEvents
     });
+
+    if (!gte('3.10.0')) {
+      return task;
+    }
+
+    const perform = (...args) => task.perform(...args);
+    Object.setPrototypeOf(perform, task);
+
+    return perform;
   });
 
   tp.taskFn = taskFn;

--- a/tests/unit/task-property-test.js
+++ b/tests/unit/task-property-test.js
@@ -2,16 +2,17 @@ import { run } from '@ember/runloop';
 import { defer } from 'rsvp';
 import EmberObject from '@ember/object';
 import { task } from 'ember-concurrency';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
+import { gte } from 'ember-compatibility-helpers';
 
 let taskRunCounter = 0;
 function taskCounterWrapper(taskProperty) {
   let originalTaskFn = taskProperty.taskFn;
 
-  taskProperty.taskFn = function * (...args) {
+  taskProperty.taskFn = function*(...args) {
     taskRunCounter += 1;
     try {
-      return yield * originalTaskFn.apply(this, args);
+      return yield* originalTaskFn.apply(this, args);
     } finally {
       taskRunCounter -= 1;
     }
@@ -21,11 +22,13 @@ function taskCounterWrapper(taskProperty) {
 }
 
 module('Unit: task property', function() {
-  test("`TaskProperty`s can be extended with custom functionality / decoration", function(assert) {
+  test('`TaskProperty`s can be extended with custom functionality / decoration', function(assert) {
     let Obj = EmberObject.extend({
-      doStuff: taskCounterWrapper(task(function * () {
-        yield defer().promise;
-      }))
+      doStuff: taskCounterWrapper(
+        task(function*() {
+          yield defer().promise;
+        })
+      )
     });
 
     let obj;
@@ -49,6 +52,30 @@ module('Unit: task property', function() {
       obj.get('doStuff').cancelAll();
     });
 
+    assert.equal(taskRunCounter, 0);
+  });
+
+  (gte('3.10.0')
+    ? test
+    : skip)('Plain invocation on decorated `TaskProperty`s can be used', function(assert) {
+    let Obj = EmberObject.extend({
+      doStuff: taskCounterWrapper(
+        task(function*() {
+          yield defer().promise;
+        })
+      )
+    });
+
+    const obj = Obj.create();
+    assert.equal(taskRunCounter, 0);
+
+    obj.doStuff();
+    assert.equal(taskRunCounter, 1);
+
+    obj.doStuff();
+    assert.equal(taskRunCounter, 2);
+
+    obj.doStuff.cancelAll();
     assert.equal(taskRunCounter, 0);
   });
 });


### PR DESCRIPTION
Implements #240.

For some reason changing `numRunning` and `numQueued`, if accessed via `taskInstance.task`, do not trigger an update. If accessed via `taskInstance.owner[taskInstance.task.name]`, it works. This has to be a problem with the tracking system.

https://github.com/machty/ember-concurrency/blob/62c942d7f41e1555ab835ba921f1293f0c8d1984/addon/-scheduler.js#L94-L97

Unfortunately `Acceptance | injections on encapsulated tests: encapsulated tasks support injections` is also failing.