### PR TITLE
Revert Ember support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,11 @@ env:
   matrix:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
+    - EMBER_TRY_SCENARIO=ember-lts-2.4
+    - EMBER_TRY_SCENARIO=ember-lts-2.8
+    - EMBER_TRY_SCENARIO=ember-lts-2.12
+    - EMBER_TRY_SCENARIO=ember-lts-2.16
+    - EMBER_TRY_SCENARIO=ember-lts-2.18
     - EMBER_TRY_SCENARIO=ember-lts-3.4
     - EMBER_TRY_SCENARIO=ember-release
     - EMBER_TRY_SCENARIO=ember-beta

--- a/README.md
+++ b/README.md
@@ -43,6 +43,6 @@ See the [Contributing](CONTRIBUTING.md) guide for details.
 [npm-badge-link]: http://badge.fury.io/js/ember-concurrency
 [ember-observer-badge]: http://emberobserver.com/badges/ember-concurrency.svg
 [ember-observer-url]: http://emberobserver.com/addons/ember-concurrency
-[ember-version]: https://embadge.io/v1/badge.svg?start=1.13.0
+[ember-version]: https://img.shields.io/badge/Ember-2.4%2B-brightgreen.svg
 [twiddle-starter]: https://ember-twiddle.com/b2b0c016f4df24261381487b60c707f3?numColumns=2&openFiles=templates.application.hbs%2Ctemplates.application.hbs
 

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -12,6 +12,59 @@ module.exports = function() {
       useYarn: true,
       scenarios: [
         {
+          name: 'ember-lts-2.4',
+          bower: {
+            dependencies: {
+              'ember': 'components/ember#lts-2-4'
+            },
+            resolutions: {
+              'ember': 'lts-2-4'
+            }
+          },
+          npm: {
+            devDependencies: {
+              'ember-source': null
+            }
+          }
+        },
+        {
+          name: 'ember-lts-2.8',
+          bower: {
+            dependencies: {
+              'ember': 'components/ember#lts-2-8'
+            },
+            resolutions: {
+              'ember': 'lts-2-8'
+            }
+          },
+        },
+        {
+          name: 'ember-lts-2.12',
+          npm: {
+            devDependencies: {
+              'ember-source': '~2.12.0'
+            }
+          }
+        },
+        {
+          name: 'ember-lts-2.16',
+          npm: {
+            devDependencies: {
+              'ember-native-dom-event-dispatcher': '^0.6.4',
+              'ember-source': '~2.16.0'
+            }
+          }
+        },
+        {
+          name: 'ember-lts-2.18',
+          npm: {
+            devDependencies: {
+              'ember-native-dom-event-dispatcher': '^0.6.4',
+              'ember-source': '~2.18.0'
+            }
+          }
+        },
+        {
           name: 'ember-lts-3.4',
           npm: {
             devDependencies: {


### PR DESCRIPTION
As discussed in #290 this reverts the dropped support for older Ember versions and their test matrix in that PR to cover all the previously supported Ember versions, which were starting at 2.4. 

Although the Readme's badge (which was broken) stated support for Ember 1.13, but tests failed for that version. Didn't dig into it, but updated (fixed) the badge with Ember 2.4 as the minimum supported and tested version. Agree?

