### PR TITLE
utils/rawTimeout: Use `clearTimeout()` instead of `clearInterval()`

### DIFF
--- a/addon/utils.js
+++ b/addon/utils.js
@@ -176,7 +176,7 @@ export function rawTimeout(ms) {
         taskInstance.proceed(resumeIndex, YIELDABLE_CONTINUE, this._result);
       }, ms);
       return () => {
-        window.clearInterval(timerId);
+        clearTimeout(timerId);
       };
     }
   };


### PR DESCRIPTION
When writing tests that fake time with `lolex` it complains:

> Cannot clear timer: timer created with setTimeout() but cleared with clearInterval()

There is no clear reason for using `clearInterval()` here for something that was created with `setTimeout()`. Using `clearTimeout()` instead seems more straight forward and would solve this issue.

---
Unrelated: I noticed that `rawTimeout()` is undocumented and not exported from the top-level file. Is there a reason for that? Is it not supposed to be used?