### PR TITLE
Export `rawTimeout` from `ember-concurrency` module 

### DIFF
--- a/addon/index.js
+++ b/addon/index.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
 import { computed } from '@ember/object';
-import { timeout, forever } from './utils';
+import { timeout, forever, rawTimeout } from './utils';
 import { Task, TaskProperty } from './-task-property';
 import { didCancel } from './-task-instance';
 import { TaskGroup, TaskGroupProperty } from './-task-group';
@@ -143,6 +143,7 @@ export {
   hash,
   race,
   timeout,
+  rawTimeout,
   waitForQueue,
   waitForEvent,
   waitForProperty,

--- a/addon/utils.js
+++ b/addon/utils.js
@@ -98,6 +98,11 @@ export const _ComputedProperty = ComputedProperty;
  * Yielding `timeout(ms)` will pause a task for the duration
  * of time passed in, in milliseconds.
  *
+ * This timeout will be scheduled on the Ember runloop, which
+ * means that test helpers will wait for it to complete before
+ * continuing with the test. See `rawTimeout()` if you need
+ * different behavior.
+ *
  * The task below, when performed, will print a message to the
  * console every second.
  *
@@ -169,6 +174,32 @@ export function raw(value) {
   return new RawValue(value);
 }
 
+/**
+ *
+ * Yielding `rawTimeout(ms)` will pause a task for the duration
+ * of time passed in, in milliseconds.
+ *
+ * The timeout will use the native `setTimeout()` browser API,
+ * instead of the Ember runloop, which means that test helpers
+ * will *not* wait for it to complete.
+ *
+ * The task below, when performed, will print a message to the
+ * console every second.
+ *
+ * ```js
+ * export default Component.extend({
+ *   myTask: task(function * () {
+ *     while (true) {
+ *       console.log("Hello!");
+ *       yield rawTimeout(1000);
+ *     }
+ *   })
+ * });
+ * ```
+ *
+ * @param {number} ms - the amount of time to sleep before resuming
+ *   the task, in milliseconds
+ */
 export function rawTimeout(ms) {
   return {
     [yieldableSymbol](taskInstance, resumeIndex) {

--- a/tests/dummy/app/testing-ergo/foo-settimeout/controller.js
+++ b/tests/dummy/app/testing-ergo/foo-settimeout/controller.js
@@ -1,6 +1,5 @@
 import Controller from '@ember/controller';
-import { task } from 'ember-concurrency';
-import { rawTimeout } from 'ember-concurrency/utils';
+import { task, rawTimeout } from 'ember-concurrency';
 
 export default Controller.extend({
   isShowingButton: false,


### PR DESCRIPTION
`rawTimeout` was previously only available from `ember-concurrency/utils`. This PR promotes it to be available from the top-level module.