### PR TITLE
Ensure waitForQueue throws on errors

### DIFF
--- a/addon/-wait-for.js
+++ b/addon/-wait-for.js
@@ -6,7 +6,8 @@ import { isEventedObject, yieldableToPromise } from './utils';
 
 import {
   yieldableSymbol,
-  YIELDABLE_CONTINUE
+  YIELDABLE_CONTINUE,
+  YIELDABLE_THROW
 } from './utils';
 
 class WaitFor {
@@ -22,9 +23,13 @@ class WaitForQueueYieldable extends WaitFor {
   }
 
   [yieldableSymbol](taskInstance, resumeIndex) {
-    schedule(this.queueName, () => {
-      taskInstance.proceed(resumeIndex, YIELDABLE_CONTINUE, null);
-    });
+    try {
+      schedule(this.queueName, () => {
+        taskInstance.proceed(resumeIndex, YIELDABLE_CONTINUE, null);
+      });
+    } catch(error) {
+      taskInstance.proceed(resumeIndex, YIELDABLE_THROW, error);
+    }
   }
 }
 

--- a/tests/unit/wait-for-test.js
+++ b/tests/unit/wait-for-test.js
@@ -49,6 +49,28 @@ module('Unit: test waitForQueue and waitForEvent and waitForProperty', function(
     assert.notOk(taskCompleted, 'Task should not have completed');
   });
 
+  test('waitForQueue throws if invalid queue is used', function(assert) {
+    assert.expect(2);
+
+    let taskErrored = false;
+    const Obj = EmberObject.extend({
+      task: task(function*() {
+        try {
+          yield waitForQueue('non-existing-queue');
+        } catch(error) {
+          assert.equal(error.toString(), 'Error: You attempted to schedule an action in a queue (non-existing-queue) that doesn\'t exist', 'it correctly bubbles error up');
+          taskErrored = true;
+        }
+      })
+    });
+
+    run(() => {
+      let obj = Obj.create();
+      obj.get('task').perform();
+      assert.notOk(taskErrored, 'Task should have errored');
+    });
+  });
+
   test('waitForEvent works (`Ember.Evented` interface)', function(assert) {
     assert.expect(4);
     let taskCompleted = false;


### PR DESCRIPTION
I ran into an issue, where `waitForQueue()` would never resolve. After some digging, I found out it was because I used `waitForQueue('sync')`, but the `sync` runloop was removed in 3.11. However, this was totally swallowed by `waitForQueue`, although e.g. `schedule('sync', func)` _did_ actually throw a descriptive error.

This PR fixes this by ensuring that an error thrown bubbles up correctly.