### PR TITLE
Ensure tasks are assigned to a container

### DIFF
--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -2,7 +2,7 @@ import { scheduleOnce } from '@ember/runloop';
 import { addObserver } from '@ember/object/observers';
 import { addListener } from '@ember/object/events';
 import EmberObject from '@ember/object';
-import { getOwner } from '@ember/application';
+import { getOwner, setOwner } from '@ember/application';
 import { default as TaskInstance, getRunningInstance } from './-task-instance';
 import {
   PERFORM_TYPE_DEFAULT,
@@ -382,6 +382,8 @@ export const Task = EmberObject.extend(TaskStateMixin, {
       _origin: this,
       _performType: performType,
     });
+
+    setOwner(taskInstance, getOwner(this.context));
 
     if (performType === PERFORM_TYPE_LINKED) {
       linkedObject._expectsLinkedYield = true;

--- a/tests/dummy/app/task-injection-test/controller.js
+++ b/tests/dummy/app/task-injection-test/controller.js
@@ -7,7 +7,7 @@ export default Controller.extend({
 
   myTask: task({
     fun: service(),
-    perform: function * () {
+    *perform() {
       let value = yield this.get('subtask').perform();
       return `${this.get('fun.foo')}-${value}`;
     },
@@ -15,10 +15,9 @@ export default Controller.extend({
     subtask: task({
       fun: service(),
       wat: 2,
-      perform: function * () {
+      *perform() {
         return this.get('fun.foo') * this.wat;
       },
     }),
   }),
 });
-


### PR DESCRIPTION
This fixes an issue with service injection inside
of encapsulated tasks on Ember 3.13+ by ensuring
tasks that are children of other tasks are
assigned a container to use for service injection.