### PR TITLE
Use ember get in case object isn't an EmberObject

### DIFF
--- a/addon/-property-modifiers-mixin.js
+++ b/addon/-property-modifiers-mixin.js
@@ -1,4 +1,5 @@
 import { assert } from '@ember/debug';
+import { get } from '@ember/object';
 import Scheduler from './-scheduler';
 import {
   enqueueTasksPolicy,
@@ -75,7 +76,7 @@ function assertModifiersNotMixedWithGroup(obj) {
 
 export function resolveScheduler(propertyObj, obj, TaskGroup) {
   if (propertyObj._taskGroupPath) {
-    let taskGroup = obj.get(propertyObj._taskGroupPath);
+    let taskGroup = get(obj, propertyObj._taskGroupPath);
     assert(`Expected path '${propertyObj._taskGroupPath}' to resolve to a TaskGroup object, but instead was ${taskGroup}`, taskGroup instanceof TaskGroup);
     return taskGroup._scheduler;
   } else {


### PR DESCRIPTION
When using a TaskGroup on an octane glimmer component `get` does not
exist on the component. Ember.get shields us from this and just works.

Fixes machty/ember-concurrency-decorators#57