### PR TITLE
Use ember get for ES Classes

### DIFF
--- a/addon/-scheduler.js
+++ b/addon/-scheduler.js
@@ -129,12 +129,12 @@ function flushTaskCounts(tasks) {
 function updateTaskChainCounts(task) {
   let numRunning = task.numRunning;
   let numQueued  = task.numQueued;
-  let taskGroup = task.get('group');
+  let taskGroup = get(task, 'group');
 
   while (taskGroup) {
     set(taskGroup, 'numRunning', numRunning);
     set(taskGroup, 'numQueued', numQueued);
-    taskGroup = taskGroup.get('group');
+    taskGroup = get(taskGroup, 'group');
   }
 }
 

--- a/addon/-task-state-mixin.js
+++ b/addon/-task-state-mixin.js
@@ -1,6 +1,6 @@
 import { gt } from '@ember/object/computed';
 import Mixin from '@ember/object/mixin';
-import { computed } from '@ember/object';
+import { computed, get } from '@ember/object';
 const { alias } = computed;
 
 // this is a mixin of properties/methods shared between Tasks and TaskGroups
@@ -52,7 +52,7 @@ export default Mixin.create({
   },
 
   group: computed(function() {
-    return this._taskGroupPath && this.context.get(this._taskGroupPath);
+    return this._taskGroupPath && get(this.context, this._taskGroupPath);
   }),
 
   _scheduler: null,


### PR DESCRIPTION
I missed some of these in #321. Though only the one in `-task-state-mixin.js ` seems to be an issue for my application, I didn't see the harm in protecting the others as well.

I did a walk through of all other instances of `.get()` not on `this` and these were the last ones I could find.