### PR TITLE
Refactor yieldable cancelation to work with cancelable promise helpers

### DIFF
--- a/addon/-cancelable-promise-helpers.js
+++ b/addon/-cancelable-promise-helpers.js
@@ -1,7 +1,7 @@
 import { assert } from '@ember/debug';
 import RSVP, { Promise } from 'rsvp';
 import TaskInstance from './-task-instance';
-import { yieldableSymbol } from './utils';
+import { cancelableSymbol, yieldableSymbol } from './utils';
 
 const asyncAll = taskAwareVariantOf(Promise, 'all', identity);
 
@@ -122,15 +122,15 @@ function taskAwareVariantOf(obj, method, getItems) {
         if (it) {
           if (it instanceof TaskInstance) {
             it.cancel();
-          } else if (typeof it.__ec_cancel__ === 'function') {
-            it.__ec_cancel__();
+          } else if (typeof it[cancelableSymbol] === 'function') {
+            it[cancelableSymbol]();
           }
         }
       });
     };
 
     let promise = defer.promise.finally(cancelAll);
-    promise.__ec_cancel__ = cancelAll;
+    promise[cancelableSymbol] = cancelAll;
     return promise;
   };
 }

--- a/addon/-task-instance.js
+++ b/addon/-task-instance.js
@@ -5,6 +5,7 @@ import { run, join, schedule } from '@ember/runloop';
 import EmberObject, { computed, get, set } from '@ember/object';
 import Ember from 'ember';
 import {
+  cancelableSymbol,
   yieldableSymbol,
   YIELDABLE_CONTINUE,
   YIELDABLE_THROW,
@@ -709,7 +710,7 @@ let taskInstanceAttrs = {
       return;
     }
 
-    this._addDisposer(yieldedValue.__ec_cancel__);
+    this._addDisposer(yieldedValue[cancelableSymbol]);
 
     if (yieldedValue[yieldableSymbol]) {
       this._invokeYieldable(yieldedValue);

--- a/tests/unit/buffering-test.js
+++ b/tests/unit/buffering-test.js
@@ -1,5 +1,5 @@
 import EmberObject from '@ember/object';
-import { later, run, join } from '@ember/runloop';
+import { run, join } from '@ember/runloop';
 import { task, timeout } from 'ember-concurrency';
 import { module, test } from 'qunit';
 
@@ -48,11 +48,10 @@ module('Unit: buffering', function() {
           yield timeout(10);
           arr.push(v);
           if (v === last) {
-            later(() => {
-              assert.equal(maxSem, maxConcurrency, "assert expected maxConcurrency");
-              assert.deepEqual(arr, expectations);
-              start();
-            }, 20);
+            yield timeout(20);
+            assert.equal(maxSem, maxConcurrency, "assert expected maxConcurrency");
+            assert.deepEqual(arr, expectations);
+            start();
           }
         } finally {
           bumpSemaphore(-1);


### PR DESCRIPTION
The refactor addresses some gaps between yieldable implementations
around how cancelation is handled, especially when used with cancelable promise helpers.

Resolves #308, #329