### PR TITLE
Fix use of tasks w/ action and fn helpers on 3.11+

### DIFF
--- a/addon/utils.js
+++ b/addon/utils.js
@@ -72,6 +72,8 @@ export function _cleanupOnDestroy(owner, object, cleanupMethodName, ...args) {
 export let INVOKE = "__invoke_symbol__";
 
 let locations = [
+  '@ember/-internals/glimmer/index',
+  '@ember/-internals/glimmer',
   'ember-glimmer',
   'ember-glimmer/helpers/action',
   'ember-routing-htmlbars/keywords/closure-action',

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^2.0.0",
+    "ember-fn-helper-polyfill": "^1.0.2",
     "ember-load-initializers": "^2.0.0",
     "ember-notify": "^5.3.0",
     "ember-qunit": "^4.4.1",

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -51,4 +51,22 @@ module('Acceptance | helpers', function(hooks) {
     assert.deepEqual(assertArgs, []);
     assert.equal(find('.task-status').textContent, 'someTask');
   });
+
+  test('passing a task to the action helper performs it like a regular function', async function(assert) {
+    assert.expect(2);
+    await visit('/helpers-test');
+    assert.equal(currentURL(), '/helpers-test');
+
+    await click('.action-task');
+    assert.equal(find('.task-status').textContent, 'someTask');
+  });
+
+  test('passing a task to the fn helper performs it like a regular function', async function(assert) {
+    assert.expect(2);
+    await visit('/helpers-test');
+    assert.equal(currentURL(), '/helpers-test');
+
+    await click('.action-task');
+    assert.equal(find('.task-status').textContent, 'someTask');
+  });
 });

--- a/tests/dummy/app/helpers-test/controller.js
+++ b/tests/dummy/app/helpers-test/controller.js
@@ -35,4 +35,3 @@ export default Controller.extend({
     }
   }
 });
-

--- a/tests/dummy/app/helpers-test/template.hbs
+++ b/tests/dummy/app/helpers-test/template.hbs
@@ -9,3 +9,4 @@
 <button onclick={{perform maybeNullTask}} class="maybe-null-task">Maybe Null Task</button>
 <button onclick={{action "setupTask"}} class="setup-task">Setup Task</button>
 <button onclick={{perform valueTask value="target.innerHTML"}} class="set-value-option-task">Set value option</button>
+<button onclick={{action someTask}} class="action-task">Action Task</button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4804,6 +4804,15 @@ ember-export-application-global@^2.0.0:
   dependencies:
     ember-cli-babel "^6.0.0-beta.7"
 
+ember-fn-helper-polyfill@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/ember-fn-helper-polyfill/-/ember-fn-helper-polyfill-1.0.2.tgz#deb035fced77f98b9256ba4eb17694b7a2e2a526"
+  integrity sha512-T/YG1Do59xvyMCUItqvY61ZJfSLiUsUuykG8C4o9ffrwDuspbquL3eJdLi+NF1dNoihwcIdJHcxLKvwvQB05LQ==
+  dependencies:
+    calculate-cache-key-for-tree "^2.0.0"
+    ember-cli-babel "^7.7.3"
+    ember-cli-version-checker "^3.1.3"
+
 ember-load-initializers@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/ember-load-initializers/-/ember-load-initializers-2.1.0.tgz#b402815ab9c823ff48a1369b52633721987e72d4"


### PR DESCRIPTION
Builds on @thiagofelix's find in #312 (which fixes for 3.1 - 3.10ish), and adds the latest paths for `INVOKE` to work with 3.11+  and some tests for use with `action` and `fn` helpers