### PR TITLE
Add some brief documentation on use with Octane/decorators

### DIFF
--- a/tests/dummy/app/components/task-function-syntax-5/component.js
+++ b/tests/dummy/app/components/task-function-syntax-5/component.js
@@ -1,0 +1,18 @@
+// BEGIN-SNIPPET task-function-syntax-5
+import Component from '@glimmer/component';
+import { tracked } from '@glimmer/tracking';
+import { task } from 'ember-concurrency';
+
+export default class MyOctaneComponent extends Component {
+  @tracked status = null
+
+  @(task(function * () {
+    let nums = [];
+    for (let i = 0; i < 3; i++) {
+      nums.push(Math.floor(Math.random() * 10));
+    }
+
+    this.status = `My favorite numbers: ${nums.join(', ')}`;
+  })) pickRandomNumbers;
+}
+// END-SNIPPET

--- a/tests/dummy/app/docs/task-function-syntax/template.hbs
+++ b/tests/dummy/app/docs/task-function-syntax/template.hbs
@@ -73,3 +73,25 @@
   use <code>yield</code>.
 </p>
 
+<h4>ES Native Class Use (Ember 3.10+)</h4>
+
+<p>
+  As of Ember 3.10, <code>task()</code> can be used as a decorator, allowing use
+  with native ES classes, such as Glimmer components. The usage remains much the
+  same, but the syntax is slightly different.
+</p>
+
+{{code-snippet name="task-function-syntax-5.js"}}
+
+<p>
+  This syntax is a bit verbose compared to the <code>EmberObject</code> syntax.
+  There is an experimental (though stable) Ember addon that adds more concise
+  decorators, such as decorators on generator methods. See documentation
+  for <a href="https://github.com/machty/ember-concurrency-decorators">ember-concurrency-decorators</a>
+  for more details on usage.
+</p>
+
+<p>
+  As decorators in ECMAScript mature through the TC39, improvements will be made
+  to the decorator experience with ember-concurrency.
+</p>


### PR DESCRIPTION
Raised in issue #271, there is currently no official documentation
on using ember-concurrency with native classes and other Octane-related
use-cases.

This adds a brief section to "Task Function Syntax" in the docs that
shows an example of use with a Glimmer component and mentions the
ember-concurrency-decorators addon as a more concise approach to the
default decorators via the task() property.

Thanks @jenweber for the Glimmer example!