### PR TITLE
Remove uses of get() internally that could result in auto-tracking and rerender assertions

### DIFF
--- a/addon/-encapsulated-task.js
+++ b/addon/-encapsulated-task.js
@@ -3,11 +3,10 @@ import TaskInstance from './-task-instance';
 
 export default TaskInstance.extend({
   _makeIterator() {
-    let perform = this.get('perform');
+    let perform = this.perform;
     assert("The object passed to `task()` must define a `perform` generator function, e.g. `perform: function * (a,b,c) {...}`, or better yet `*perform(a,b,c) {...}`", typeof perform === 'function');
     return perform.apply(this, this.args);
   },
 
   perform: null,
 });
-

--- a/addon/-scheduler.js
+++ b/addon/-scheduler.js
@@ -142,7 +142,7 @@ function filterFinished(taskInstances) {
   let ret = [];
   for (let i = 0, l = taskInstances.length; i < l; ++i) {
     let taskInstance = taskInstances[i];
-    if (get(taskInstance, 'isFinished') === false) {
+    if (taskInstance.isFinished === false) {
       ret.push(taskInstance);
     }
   }


### PR DESCRIPTION
In Ember 3.15+, 'get' from @ember/object will auto-track properties when used outside of certain
allowed contexts. This will cause a rerender assertion if later those properties are set within
the same render cycle. In general, we don't need to track these properties this way.

Fixes #340 (hopefully). Still need to add a test