### PR TITLE
Add documentation around use of @computed

### DIFF
--- a/tests/dummy/app/components/task-function-syntax-5/component.js
+++ b/tests/dummy/app/components/task-function-syntax-5/component.js
@@ -1,10 +1,20 @@
 // BEGIN-SNIPPET task-function-syntax-5
 import Component from '@glimmer/component';
 import { tracked } from '@glimmer/tracking';
+import { computed } from '@ember/object';
 import { task } from 'ember-concurrency';
 
 export default class MyOctaneComponent extends Component {
   @tracked status = null
+
+  @computed('pickRandomNumbers.last.value')
+  get favoriteNumbers() {
+    if (this.pickRandomNumbers.last) {
+      return this.pickRandomNumbers.last.value
+    }
+
+    return [];
+  }
 
   @(task(function * () {
     let nums = [];
@@ -13,6 +23,8 @@ export default class MyOctaneComponent extends Component {
     }
 
     this.status = `My favorite numbers: ${nums.join(', ')}`;
+
+    return nums;
   })) pickRandomNumbers;
 }
 // END-SNIPPET

--- a/tests/dummy/app/docs/task-function-syntax/template.hbs
+++ b/tests/dummy/app/docs/task-function-syntax/template.hbs
@@ -73,12 +73,18 @@
   use <code>yield</code>.
 </p>
 
-<h4>ES Native Class Use (Ember 3.10+)</h4>
+<h4>ES Native Class Use (Ember 3.10+ and Ember Octane)</h4>
 
 <p>
   As of Ember 3.10, <code>task()</code> can be used as a decorator, allowing use
   with native ES classes, such as Glimmer components. The usage remains much the
   same, but the syntax is slightly different.
+</p>
+
+<p>
+  Note as well, the use of the <code>@computed</code> decorator on the native ES
+  getter <code>favoriteNumbers</code>. This is required for updates to be
+  reflected in the UI, if you were to use it within the template.
 </p>
 
 {{code-snippet name="task-function-syntax-5.js"}}


### PR DESCRIPTION
As found in #343, `@computed` is required for native getters that access derived state on Tasks.