### PR TITLE
[v2] Use @tracked underneath on Ember 3.16+

### DIFF
--- a/addon/-private/ember-environment.js
+++ b/addon/-private/ember-environment.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { defer } from 'rsvp';
 import { Environment } from "./external/environment";
 import { assert } from '@ember/debug';
-import { join, schedule } from '@ember/runloop';
+import { join, schedule, later } from '@ember/runloop';
 
 export class EmberEnvironment extends Environment {
   assert(...args) {
@@ -14,7 +14,7 @@ export class EmberEnvironment extends Environment {
   }
 
   reportUncaughtRejection(error) {
-    setTimeout(function() {
+    later(function() {
       if (Ember.onerror) {
         Ember.onerror(error);
       } else {

--- a/addon/-private/external/scheduler/policies/execution-states.js
+++ b/addon/-private/external/scheduler/policies/execution-states.js
@@ -1,4 +1,3 @@
-// TODO: change to ints?
 export const TYPE_CANCELLED = "CANCELLED";
 export const TYPE_STARTED = "STARTED";
 export const TYPE_QUEUED = "QUEUED";

--- a/addon/-private/external/scheduler/refresh.js
+++ b/addon/-private/external/scheduler/refresh.js
@@ -58,7 +58,7 @@ class Refresh {
         taskInstance.cancel(desiredState.reason);
         return false;
       case TYPE_STARTED:
-        if (!taskInstance.hasStarted) {
+        if (!taskInstance.executor.state.hasStarted) {
           this.startingInstances.push(taskInstance);
           taskState.onStart(taskInstance);
         }

--- a/addon/-private/external/task-instance/executor.js
+++ b/addon/-private/external/task-instance/executor.js
@@ -70,7 +70,7 @@ export class TaskInstanceExecutor {
 
   setState(state) {
     Object.assign(this.state, state);
-    this.taskInstance.setState(state);
+    this.taskInstance.setState(this.state);
   }
 
   proceedChecked(index, yieldResumeType, value) {

--- a/addon/-private/external/task/taskable.js
+++ b/addon/-private/external/task/taskable.js
@@ -32,7 +32,7 @@ export class Taskable {
   }
 
   _resetState() {
-    this.setProperties(DEFAULT_STATE);
+    this.setState(DEFAULT_STATE);
   }
 
   // override

--- a/addon/-private/task-group.js
+++ b/addon/-private/task-group.js
@@ -1,6 +1,11 @@
 import { TaskGroup as TaskGroupBase } from "./external/task/task-group";
 import { TASKABLE_MIXIN } from "./taskable-mixin";
+import { TRACKED_INITIAL_TASK_STATE } from "./tracked-state";
 
 export class TaskGroup extends TaskGroupBase { }
+
+if (TRACKED_INITIAL_TASK_STATE) {
+  Object.defineProperties(TaskGroup.prototype, TRACKED_INITIAL_TASK_STATE);
+}
 
 Object.assign(TaskGroup.prototype, TASKABLE_MIXIN);

--- a/addon/-private/task-instance.js
+++ b/addon/-private/task-instance.js
@@ -1,5 +1,6 @@
 import { set, get, setProperties } from '@ember/object';
 import { BaseTaskInstance } from './external/task-instance/base';
+import { TRACKED_INITIAL_INSTANCE_STATE } from './tracked-state';
 
 /**
   A `TaskInstance` represent a single execution of a
@@ -275,4 +276,8 @@ export class TaskInstance extends BaseTaskInstance {
   set(key, value) {
     return set(this, key, value);
   }
+}
+
+if (TRACKED_INITIAL_INSTANCE_STATE) {
+  Object.defineProperties(TaskInstance.prototype, TRACKED_INITIAL_INSTANCE_STATE);
 }

--- a/addon/-private/task-instance.js
+++ b/addon/-private/task-instance.js
@@ -1,6 +1,9 @@
 import { set, get, setProperties } from '@ember/object';
 import { BaseTaskInstance } from './external/task-instance/base';
-import { TRACKED_INITIAL_INSTANCE_STATE } from './tracked-state';
+import {
+  TRACKED_INITIAL_INSTANCE_STATE,
+  USE_TRACKED
+} from './tracked-state';
 
 /**
   A `TaskInstance` represent a single execution of a
@@ -21,30 +24,31 @@ import { TRACKED_INITIAL_INSTANCE_STATE } from './tracked-state';
   @class TaskInstance
 */
 
+const assignProperties = USE_TRACKED ? Object.assign : setProperties;
+
 export class TaskInstance extends BaseTaskInstance {
   setState(props) {
-    setProperties(this, props);
-    let state = this._recomputeState();
-    setProperties(this, {
-      isRunning: !this.isFinished,
+    let state = this._recomputeState(props);
+    assignProperties(this, {
+      ...props,
+      isRunning: !props.isFinished,
       isDropped: state === 'dropped',
       state,
     });
   }
 
-  _recomputeState() {
-    if (this.isDropped) {
+  _recomputeState(props) {
+    if (props.isDropped) {
       return 'dropped';
-    } else
-    if (this.isCanceled) {
-      if (this.hasStarted) {
+    } else if (props.isCanceled) {
+      if (props.hasStarted) {
         return 'canceled';
       } else {
         return 'dropped';
       }
-    } else if (this.isFinished) {
+    } else if (props.isFinished) {
       return 'finished';
-    } else if (this.hasStarted) {
+    } else if (props.hasStarted) {
       return 'running';
     } else {
       return 'waiting';

--- a/addon/-private/task.js
+++ b/addon/-private/task.js
@@ -4,13 +4,13 @@ import { TaskInstance } from './task-instance';
 import { PERFORM_TYPE_DEFAULT, TaskInstanceExecutor, PERFORM_TYPE_LINKED } from "./external/task-instance/executor";
 import { EMBER_ENVIRONMENT } from "./ember-environment";
 import { TASKABLE_MIXIN } from "./taskable-mixin";
+import { TRACKED_INITIAL_TASK_STATE } from "./tracked-state";
 import { CANCEL_KIND_LIFESPAN_END } from "./external/task-instance/cancelation";
 import { cleanupOnDestroy } from "./external/lifespan";
 
 export class Task extends BaseTask {
   constructor(options) {
     super(options);
-    this.setState({}); // TODO: double check this is necessary
 
     cleanupOnDestroy(this.context, this, 'willDestroy', 'cancelAll', {
       reason: 'the object it lives on was destroyed or unrendered',
@@ -201,6 +201,10 @@ export class Task extends BaseTask {
   [INVOKE](...args) {
     return this.perform(...args);
   }
+}
+
+if (TRACKED_INITIAL_TASK_STATE) {
+  Object.defineProperties(Task.prototype, TRACKED_INITIAL_TASK_STATE);
 }
 
 Object.assign(Task.prototype, TASKABLE_MIXIN);

--- a/addon/-private/taskable-mixin.js
+++ b/addon/-private/taskable-mixin.js
@@ -2,16 +2,15 @@ import { set, get, setProperties } from '@ember/object';
 
 export const TASKABLE_MIXIN = {
   setState(state) {
-    this.setProperties(state);
-    let isRunning = this.numRunning > 0;
-    let isQueued = this.numQueued > 0;
-    let derivedState = {
+    let isRunning = state.numRunning > 0;
+    let isQueued = state.numQueued > 0;
+    let derivedState = Object.assign(state, {
       performCount: this.performCount + (state.numPerformedInc || 0),
       isRunning,
       isQueued,
       isIdle: !isRunning && !isQueued,
       state: isRunning ? "running" : "idle",
-    };
+    });
     setProperties(this, derivedState);
   },
 

--- a/addon/-private/taskable-mixin.js
+++ b/addon/-private/taskable-mixin.js
@@ -1,4 +1,5 @@
 import { set, get, setProperties } from '@ember/object';
+import { USE_TRACKED } from './tracked-state';
 
 export const TASKABLE_MIXIN = {
   _performCount: 0,
@@ -8,14 +9,14 @@ export const TASKABLE_MIXIN = {
 
     let isRunning = state.numRunning > 0;
     let isQueued = state.numQueued > 0;
-    let derivedState = Object.assign(state, {
+    let derivedState = Object.assign({}, state, {
       performCount: this._performCount,
       isRunning,
       isQueued,
       isIdle: !isRunning && !isQueued,
       state: isRunning ? "running" : "idle",
     });
-    setProperties(this, derivedState);
+    this.setProperties(derivedState);
   },
 
   get(key) {
@@ -27,7 +28,11 @@ export const TASKABLE_MIXIN = {
   },
 
   setProperties(props) {
-    return setProperties(this, props);
+    if (USE_TRACKED) {
+      Object.assign(this, props);
+    } else {
+      setProperties(this, props);
+    }
   },
 
   onState(state, task) {

--- a/addon/-private/taskable-mixin.js
+++ b/addon/-private/taskable-mixin.js
@@ -1,11 +1,15 @@
 import { set, get, setProperties } from '@ember/object';
 
 export const TASKABLE_MIXIN = {
+  _performCount: 0,
+
   setState(state) {
+    this._performCount = this._performCount + (state.numPerformedInc || 0);
+
     let isRunning = state.numRunning > 0;
     let isQueued = state.numQueued > 0;
     let derivedState = Object.assign(state, {
-      performCount: this.performCount + (state.numPerformedInc || 0),
+      performCount: this._performCount,
       isRunning,
       isQueued,
       isIdle: !isRunning && !isQueued,

--- a/addon/-private/tracked-state.js
+++ b/addon/-private/tracked-state.js
@@ -7,7 +7,7 @@ import {
   INITIAL_STATE as INITIAL_INSTANCE_STATE
 } from "./external/task-instance/initial-state";
 
-const USE_TRACKED = gte('3.16.0');
+export const USE_TRACKED = gte('3.16.0');
 
 function trackMixin(proto, obj, key) {
   const propDesc = Object.getOwnPropertyDescriptor(proto, key);

--- a/addon/-private/tracked-state.js
+++ b/addon/-private/tracked-state.js
@@ -1,0 +1,49 @@
+import { gte } from 'ember-compatibility-helpers';
+import { tracked } from '@glimmer/tracking';
+import {
+  DEFAULT_STATE as INITIAL_TASK_STATE
+} from "./external/task/default-state";
+import {
+  INITIAL_STATE as INITIAL_INSTANCE_STATE
+} from "./external/task-instance/initial-state";
+
+const USE_TRACKED = gte('3.16.0');
+
+function trackMixin(proto, obj, key) {
+  const propDesc = Object.getOwnPropertyDescriptor(proto, key);
+  propDesc.initializer = propDesc.initializer || (() => proto[key]);
+  delete propDesc.value;
+  const desc = tracked(obj, key, propDesc);
+  obj[key] = desc;
+  return obj;
+}
+
+function applyTracked(proto, initial) {
+  return Object.keys(proto).reduce((acc, key) => {
+    return trackMixin(proto, acc, key);
+  }, initial);
+}
+
+export let TRACKED_INITIAL_TASK_STATE;
+export let TRACKED_INITIAL_INSTANCE_STATE;
+
+if (USE_TRACKED) {
+  TRACKED_INITIAL_TASK_STATE = applyTracked(INITIAL_TASK_STATE, {});
+  TRACKED_INITIAL_TASK_STATE = applyTracked({
+    numRunning: 0,
+    numQueued: 0,
+    isRunning: false,
+    isQueued: false,
+    isIdle: true,
+  }, TRACKED_INITIAL_TASK_STATE);
+
+  TRACKED_INITIAL_INSTANCE_STATE = applyTracked(INITIAL_INSTANCE_STATE, {});
+  TRACKED_INITIAL_INSTANCE_STATE = applyTracked({
+    state: 'waiting',
+    isDropped: false,
+    isRunning: false,
+  }, TRACKED_INITIAL_INSTANCE_STATE);
+
+  Object.freeze(TRACKED_INITIAL_TASK_STATE);
+  Object.freeze(TRACKED_INITIAL_INSTANCE_STATE);
+}

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "@glimmer/tracking": "^1.0.0",
     "broccoli-file-creator": "^2.1.1",
     "ember-cli-babel": "^7.7.3",
     "ember-compatibility-helpers": "^1.2.0",

--- a/tests/integration/tracked-use-test.js
+++ b/tests/integration/tracked-use-test.js
@@ -1,0 +1,56 @@
+import Component from '@ember/component';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { later } from '@ember/runloop';
+import { render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { task, timeout } from 'ember-concurrency';
+import { gte } from 'ember-compatibility-helpers';
+
+module('Integration | tracked use', function(hooks) {
+  setupRenderingTest(hooks);
+
+  if (gte('3.16.0')) {
+    test('Issue #343 | tracked use with getter', async function(assert) {
+      assert.expect(2);
+      const done = assert.async();
+
+      this.owner.register(
+        'component:e-c-test',
+        class ECTest extends Component {
+          layout = hbs`<div>{{#if this.exampleTask.isRunning}}running{{else}}{{this.value}}{{/if}}</div>`;
+
+          constructor() {
+            super(...arguments);
+            this.exampleTask.perform();
+          }
+
+          get value() {
+            if (this.exampleTask.last) {
+              return this.exampleTask.last.value;
+            }
+
+            return null;
+          }
+
+          @(task(function*() {
+            yield timeout(1000);
+            return 'done';
+          }).restartable()) exampleTask;
+        }
+      );
+
+      render(hbs`<ECTest />`);
+
+      later(() => {
+        assert.dom('div').hasText('running');
+      }, 400);
+
+      later(() => {
+        assert.dom('div').hasText('done');
+
+        done();
+      }, 1500);
+    });
+  }
+});

--- a/tests/integration/tracked-use-test.js
+++ b/tests/integration/tracked-use-test.js
@@ -4,14 +4,14 @@ import { setupRenderingTest } from 'ember-qunit';
 import { later } from '@ember/runloop';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { task, timeout } from 'ember-concurrency';
+import { task, taskGroup, timeout } from 'ember-concurrency';
 import { gte } from 'ember-compatibility-helpers';
 
 module('Integration | tracked use', function(hooks) {
   setupRenderingTest(hooks);
 
   if (gte('3.16.0')) {
-    test('Issue #343 | tracked use with getter', async function(assert) {
+    test('Issue #343 | Task: tracked use with getter', async function(assert) {
       assert.expect(2);
       const done = assert.async();
 
@@ -37,6 +37,50 @@ module('Integration | tracked use', function(hooks) {
             yield timeout(1000);
             return 'done';
           }).restartable()) exampleTask;
+        }
+      );
+
+      render(hbs`<ECTest />`);
+
+      later(() => {
+        assert.dom('div').hasText('running');
+      }, 400);
+
+      later(() => {
+        assert.dom('div').hasText('done');
+
+        done();
+      }, 1500);
+    });
+
+    test('Issue #343 | TaskGroup: tracked use with getter', async function(assert) {
+      assert.expect(2);
+      const done = assert.async();
+
+      this.owner.register(
+        'component:e-c-test',
+        class ECTest extends Component {
+          layout = hbs`<div>{{#if this.exampleGroup.isRunning}}running{{else}}{{this.value}}{{/if}}</div>`;
+
+          constructor() {
+            super(...arguments);
+            this.exampleTask.perform();
+          }
+
+          get value() {
+            if (this.exampleGroup.last) {
+              return this.exampleGroup.last.value;
+            }
+
+            return null;
+          }
+
+          @(taskGroup().restartable()) exampleGroup;
+
+          @(task(function*() {
+            yield timeout(1000);
+            return 'done';
+          }).group('exampleGroup')) exampleTask;
         }
       );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -847,6 +847,11 @@
     "@glimmer/interfaces" "^0.42.2"
     "@glimmer/vm" "^0.42.2"
 
+"@glimmer/env@^0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@glimmer/env/-/env-0.1.7.tgz#fd2d2b55a9029c6b37a6c935e8c8871ae70dfa07"
+  integrity sha1-/S0rVakCnGs3psk16MiHGucN+gc=
+
 "@glimmer/interfaces@^0.42.0", "@glimmer/interfaces@^0.42.2":
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/interfaces/-/interfaces-0.42.2.tgz#9cf8d6f8f5eee6bfcfa36919ca68ae716e1f78db"
@@ -903,10 +908,23 @@
     handlebars "^4.0.13"
     simple-html-tokenizer "^0.5.8"
 
+"@glimmer/tracking@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/tracking/-/tracking-1.0.0.tgz#aba9feeb47c48d5aadc1226b7e8d19e34031a6bc"
+  integrity sha512-OuF04ihYD/Rjvf++Rf7MzJVnawMSax/SZXEj4rlsQoMRwtQafgtkWjlFBcbBNQkJ3rev1zzfNN+3mdD2BFIaNg==
+  dependencies:
+    "@glimmer/env" "^0.1.7"
+    "@glimmer/validator" "^0.44.0"
+
 "@glimmer/util@^0.42.0", "@glimmer/util@^0.42.2":
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/util/-/util-0.42.2.tgz#9ca1631e42766ea6059f4b49d0bdfb6095aad2c4"
   integrity sha512-Heck0baFSaWDanCYtmOcLeaz7v+rSqI8ovS7twrp2/FWEteb3Ze5sWQ2BEuSAG23L/k/lzVwYM/MY7ZugxBpaA==
+
+"@glimmer/validator@^0.44.0":
+  version "0.44.0"
+  resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
+  integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
 
 "@glimmer/vm@^0.42.2":
   version "0.42.2"


### PR DESCRIPTION
This is a PR to use `@tracked` for `Task` and `TaskInstance` state on Ember 3.16+ to enable use without using `@computed` when consuming derived state.

In Ember < 3.16, e-c behaves as it currently does requiring `@computed` to track task-derived state changes.

This PR essentially replaces the state properties on the Ember implementations of `Task` and `TaskInstance` with those properties decorated with `@tracked` (done dynamically, though w/ property descriptors. not redefining them with actual decorator syntax, so there's no dependency on decorator transforms.) This incurs a little bit of a cost, since it's redefining the properties, but practically shouldn't have much effect since it's applied to the `Task` and `TaskInstance` prototypes, rather than every instance, so it would only be incurred once.

~~There's a few outstanding issues/open questions with this:~~

- ~~The [`no-render-breaking` tests](https://github.com/machty/ember-concurrency/blob/mf-v2_tracked_interop/tests/integration/no-render-breaking-test.js) are triggering re-render assertions (one of them might technically be a "correct" failure.)~~ Fixed
  - [X] ~~Seems that `setProperties` reads the properties it sets, consuming the tag and leading to the error when setting `@tracked` properties. I think this can be worked around by using `Object.assign` instead.~~
  - [X] ~~`performCount` needs to be read to be updated. Seems this is fine in some contexts, but not others? (i.e. not in the case in one of the tests)~~ Tracked internally as `_performCount` and used for reads to ensure write-only to tracked `performCount`
- ~~How does this work for add-ons that depend on ember-concurrency and support multiple Ember versions?~~
  - They'll still need to use `@computed` if they consume ember-concurrency state and support < 3.16. However, `@computed` Just Works™ with the tracked state, it seems.

 Within applications with both tracked & computed properties, if using a native getter to access task state, and wishing to use it alongside a computed property, `@dependantKeyCompat` will need to be used on the getter as expected with any other tracked-prop using getter.

I'd expect there are probably other edge-cases with this as well.

Resolves #343 