### PR TITLE
Types: Make Task, TaskInstance, and TaskGroup extend EmberObject

### DIFF
--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -235,7 +235,7 @@ export interface TaskGroup<T> {
  * because concurrency policy enforced by a
  * {@linkcode TaskProperty Task Modifier} canceled the task instance.
  */
-export interface TaskInstance<T> extends Promise<T> {
+export interface TaskInstance<T> extends Promise<T>, EmberObject {
   /**
    * If this TaskInstance runs to completion by returning a property
    * other than a rejecting promise, this property will be set

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -1,3 +1,4 @@
+import EmberObject from '@ember/object';
 import ComputedProperty from '@ember/object/computed';
 
 export type TaskGenerator<T> = Generator<any, T, any>;
@@ -29,7 +30,7 @@ export type EncapsulatedTaskDescriptorReturnType<T extends EncapsulatedTaskDescr
  * method on this object to cancel all running or enqueued
  * {@linkcode TaskInstance}s.
  */
-export interface Task<T, Args extends any[]> {
+export interface Task<T, Args extends any[]> extends EmberObject {
   /**
    * `true` if any current task instances are running.
    */

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -142,7 +142,7 @@ export interface Task<T, Args extends any[]> extends EmberObject {
  * });
  * ```
  */
-export interface TaskGroup<T> {
+export interface TaskGroup<T> extends EmberObject {
   /**
    * `true` if any current task instances are running.
    */

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -112,6 +112,12 @@ module('unit tests', () => {
     expect(t.lastIncomplete).toEqualTypeOf<MyTaskInstance | null>();
     expect(t.performCount).toBeNumber();
 
+    expect(t.get).toBeCallableWith('isRunning');
+    expect(t.get('isRunning')).toBeBoolean();
+
+    // @ts-expect-error
+    t.get('nonexistentProperty');
+
     expect(t.cancelAll).toBeCallableWith();
     expect(t.cancelAll).toBeCallableWith({});
     expect(t.cancelAll).toBeCallableWith({ reason: 'why do you care' });

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -174,6 +174,12 @@ module('unit tests', () => {
     expect(tg.lastIncomplete).toEqualTypeOf<MyTaskInstance | null>();
     expect(tg.performCount).toBeNumber();
 
+    expect(tg.get).toBeCallableWith('isRunning');
+    expect(tg.get('isRunning')).toEqualTypeOf<boolean>()
+
+    // @ts-expect-error
+    tg.get('nonexistentProperty');
+
     expect(tg.cancelAll).toBeCallableWith();
     expect(tg.cancelAll).toBeCallableWith({});
     expect(tg.cancelAll).toBeCallableWith({ reason: 'why do you care' });

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -212,6 +212,12 @@ module('unit tests', () => {
     expect(t.state).toEqualTypeOf<'dropped' | 'canceled' | 'finished' | 'running' | 'waiting'>();
     expect(t.isDropped).toBeBoolean();
 
+    expect(t.get).toBeCallableWith('value');
+    expect(t.get('value')).toEqualTypeOf<string | null>()
+
+    // @ts-expect-error
+    t.get('nonexistentProperty');
+
     expect(t.cancel).toBeCallableWith();
     expect(t.cancel).toBeCallableWith('why do you care');
     expect(t.cancel).parameters.toEqualTypeOf<[string?]>();


### PR DESCRIPTION
A `Task` is an `EmberObject`:
https://github.com/machty/ember-concurrency/blob/d066cd71a9e6abb8c749d931e971004a9930c587/addon/-task-property.js#L53-L55

This is important because the task state properties are computed properties, e.g.
https://github.com/machty/ember-concurrency/blob/d066cd71a9e6abb8c749d931e971004a9930c587/addon/-task-state-mixin.js#L14-L22
and require using `.get()` to access them in Ember < 3.1.

Update: `TaskInstance` and `TaskGroup` are also `EmberObject`s so I've included them as well.

@chancancode @dfreeman @chriskrycho