### PR TITLE
v2: bugfixes from 1.1.6 - 1.2.0

### DIFF
--- a/addon/-private/computed-properties.js
+++ b/addon/-private/computed-properties.js
@@ -640,12 +640,10 @@ function buildEncapsulatedTask(taskObj, options) {
  *
  * @returns {TaskGroup}
  */
-export function taskGroup(taskFn) {
+export function taskGroup() {
   let tp = taskComputed(function(key) {
     return new TaskGroup(sharedTaskProperties(tp, this, key));
   });
-
-  tp.taskFn = taskFn;
 
   Object.setPrototypeOf(tp, TaskGroupProperty.prototype);
 

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -12,6 +12,7 @@ import {
 export function isEventedObject(c) {
   return (c && (
     (typeof c.one === 'function' && typeof c.off === 'function') ||
+    (typeof c.on === 'function' && typeof c.off === 'function') ||
     (typeof c.addEventListener === 'function' && typeof c.removeEventListener === 'function')
   ));
 }

--- a/addon/-private/wait-for.js
+++ b/addon/-private/wait-for.js
@@ -40,6 +40,7 @@ class WaitForEventYieldable extends EmberYieldable {
     this.fn = null;
     this.didFinish = false;
     this.usesDOMEvents = false;
+    this.requiresCleanup = false;
   }
 
   [yieldableSymbol](taskInstance, resumeIndex) {
@@ -53,10 +54,13 @@ class WaitForEventYieldable extends EmberYieldable {
       // assume that we're dealing with a DOM `EventTarget`.
       this.usesDOMEvents = true;
       this.object.addEventListener(this.eventName, this.fn);
-    } else {
+    } else if (typeof this.object.one === 'function') {
       // assume that we're dealing with either `Ember.Evented` or a compatible
       // interface, like jQuery.
       this.object.one(this.eventName, this.fn);
+    } else {
+      this.requiresCleanup = true;
+      this.object.on(this.eventName, this.fn);
     }
   }
 
@@ -66,7 +70,7 @@ class WaitForEventYieldable extends EmberYieldable {
         // unfortunately this is required, because IE 11 does not support the
         // `once` option: https://caniuse.com/#feat=once-event-listener
         this.object.removeEventListener(this.eventName, this.fn);
-      } else if (!this.didFinish) {
+      } else if (!this.didFinish || this.requiresCleanup) {
         this.object.off(this.eventName, this.fn);
       }
 
@@ -154,13 +158,13 @@ export function waitForQueue(queueName) {
  * });
  * ```
  *
- * @param {object} object the Ember Object or jQuery selector (with ,on(), .one(), and .off())
+ * @param {object} object the Ember Object, jQuery element, or other object with .on() and .off() APIs
  *                 that the event fires from
  * @param {function} eventName the name of the event to wait for
  */
 export function waitForEvent(object, eventName) {
   assert(
-    `${object} must include Ember.Evented (or support \`.one()\` and \`.off()\`) or DOM EventTarget (or support \`addEventListener\` and  \`removeEventListener\`) to be able to use \`waitForEvent\``,
+    `${object} must include Ember.Evented (or support \`.on()\` and \`.off()\`) or DOM EventTarget (or support \`addEventListener\` and  \`removeEventListener\`) to be able to use \`waitForEvent\``,
     isEventedObject(object)
   );
   return new WaitForEventYieldable(object, eventName);

--- a/addon/-private/wait-for.js
+++ b/addon/-private/wait-for.js
@@ -1,6 +1,7 @@
 import { assert } from "@ember/debug";
 import { schedule, cancel } from "@ember/runloop";
 import { get } from "@ember/object";
+import { addObserver, removeObserver } from '@ember/object/observers';
 import {
   yieldableSymbol,
   YIELDABLE_CONTINUE,
@@ -105,14 +106,14 @@ class WaitForPropertyYieldable extends EmberYieldable {
     };
 
     if (!this.observerFn()) {
-      this.object.addObserver(this.key, null, this.observerFn);
+      addObserver(this.object, this.key, null, this.observerFn);
       this.observerBound = true;
     }
   }
 
   [cancelableSymbol]() {
     if (this.observerBound && this.observerFn) {
-      this.object.removeObserver(this.key, null, this.observerFn);
+      removeObserver(this.object, this.key, null, this.observerFn);
       this.observerFn = null;
     }
   }

--- a/tests/unit/wait-for-test.js
+++ b/tests/unit/wait-for-test.js
@@ -1,9 +1,10 @@
 import Evented from '@ember/object/evented';
-import EmberObject from '@ember/object';
+import EmberObject, { computed, set } from '@ember/object';
 import { run } from '@ember/runloop';
 import { module, test } from 'qunit';
 import { task, waitForQueue, waitForEvent, waitForProperty, race } from 'ember-concurrency';
 import { alias } from '@ember/object/computed';
+import { gte } from 'ember-compatibility-helpers';
 
 const EventedObject = EmberObject.extend(Evented);
 
@@ -400,4 +401,40 @@ module('Unit: test waitForQueue and waitForEvent and waitForProperty', function(
     run(obj, 'trigger', 'bar', 456);
     assert.equal(ev, 456);
   });
+
+  if (gte('3.10.0')) {
+    test('waitForProperty works on an ES class', function(assert) {
+      assert.expect(1);
+
+      let values = [];
+      class Obj {
+        a = 1;
+
+        @computed('a')
+        get b() {
+          return this.a;
+        }
+
+        @(task(function*() {
+          let result = yield waitForProperty(this, 'b', v => {
+            values.push(v);
+            return v == 3 ? 'done' : false;
+          });
+          values.push(`val=${result}`);
+        })) task;
+      }
+
+      let obj;
+      run(() => {
+        obj = new Obj();
+        obj.task.perform();
+      });
+
+      run(() => set(obj, 'a', 2));
+      run(() => set(obj, 'a', 3));
+      run(() => set(obj, 'a', 4));
+
+      assert.deepEqual(values, [1, 2, 3, 'val=3']);
+    });
+  }
 });


### PR DESCRIPTION
Cherry-picks #348, #352, and #358 into `v2`, leaving TypeScript type definitions the only thing not yet ported to `v2`