### PR TITLE
Deprecate direct usage of task with action helper and disable tests for it on 3.20+

### DIFF
--- a/addon/-cancelable-promise-helpers.js
+++ b/addon/-cancelable-promise-helpers.js
@@ -28,7 +28,7 @@ export const all = (things) => {
   assert(`'all' expects an array.`, Array.isArray(things));
 
   if (things.length === 0) {
-    return things;
+    return Promise.resolve(things);
   }
 
   for (let i = 0; i < things.length; ++i) {
@@ -55,7 +55,7 @@ export const all = (things) => {
   if (isAsync) {
     return asyncAll(taskInstances);
   } else {
-    return taskInstances.map(ti => ti.value);
+    return Promise.resolve(taskInstances.map(ti => ti.value));
   }
 };
 

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -18,7 +18,7 @@ import {
   _ComputedProperty,
 } from './utils';
 import EncapsulatedTask from './-encapsulated-task';
-import { deprecate } from '@ember/debug';
+import { assert, deprecate } from '@ember/debug';
 import { gte } from 'ember-compatibility-helpers';
 
 const PerformProxy = EmberObject.extend({
@@ -400,6 +400,16 @@ export const Task = EmberObject.extend(TaskStateMixin, {
   },
 
   [INVOKE](...args) {
+    let invokeMsg = `As of Ember 3.20, invoking tasks directly with action or fn helpers is no longer supported due to underlying changes in Ember. Please use the \`perform\` helper instead, or wrap the task (e.g. \`(perform ${this._propertyName})\`) before passing it to the action or fn helpers.`;
+
+    if (gte('3.20.0')) {
+      assert(invokeMsg, false);
+    } else {
+      deprecate(invokeMsg, false, {
+        until: '2.0.0',
+        id: 'ember-concurrency.custom-invoke-invokable',
+      });
+    }
     return this.perform(...args);
   },
 });

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -102,6 +102,14 @@ module.exports = async function() {
         }
       },
       {
+        name: 'ember-lts-3.20',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.20.0'
+          }
+        }
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -51,22 +51,4 @@ module('Acceptance | helpers', function(hooks) {
     assert.deepEqual(assertArgs, []);
     assert.equal(find('.task-status').textContent, 'someTask');
   });
-
-  test('passing a task to the action helper performs it like a regular function', async function(assert) {
-    assert.expect(2);
-    await visit('/helpers-test');
-    assert.equal(currentURL(), '/helpers-test');
-
-    await click('.action-task');
-    assert.equal(find('.task-status').textContent, 'someTask');
-  });
-
-  test('passing a task to the fn helper performs it like a regular function', async function(assert) {
-    assert.expect(2);
-    await visit('/helpers-test');
-    assert.equal(currentURL(), '/helpers-test');
-
-    await click('.action-task');
-    assert.equal(find('.task-status').textContent, 'someTask');
-  });
 });

--- a/tests/dummy/app/helpers-test/template.hbs
+++ b/tests/dummy/app/helpers-test/template.hbs
@@ -9,4 +9,4 @@
 <button onclick={{perform maybeNullTask}} class="maybe-null-task">Maybe Null Task</button>
 <button onclick={{action "setupTask"}} class="setup-task">Setup Task</button>
 <button onclick={{perform valueTask value="target.innerHTML"}} class="set-value-option-task">Set value option</button>
-<button onclick={{action someTask}} class="action-task">Action Task</button>
+<button onclick={{action (perform someTask)}} class="action-task">Action Task</button>

--- a/tests/integration/helpers/invokable-action-test.js
+++ b/tests/integration/helpers/invokable-action-test.js
@@ -1,0 +1,35 @@
+import Component from '@ember/component';
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { find, click, render } from '@ember/test-helpers';
+import hbs from 'htmlbars-inline-precompile';
+import { task } from 'ember-concurrency';
+import { gte } from 'ember-compatibility-helpers';
+
+module('Integration | Helper | invokable action test', function(hooks) {
+  setupRenderingTest(hooks);
+
+  if (!gte("3.20.0")) {
+    test('passing a task to the action helper performs it like a regular function', async function(assert) {
+      assert.expect(1);
+
+      this.owner.register('component:my-component', Component.extend({
+        someTask: task(function * () {
+          this.set('status', 'someTask');
+        }),
+      }));
+
+      this.owner.register('template:components/my-component', hbs`
+        <p class="task-status">{{status}}</p>
+        <button onclick={{action someTask}} class="action-task">
+          Action Task
+        </button>
+      `);
+
+      await render(hbs`{{my-component}}`);
+
+      await click('.action-task');
+      assert.equal(find('.task-status').textContent, 'someTask');
+    });
+  }
+});

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -1387,17 +1387,15 @@ module('unit tests', () => {
     let thenable!: PromiseLike<number>;
     let promise!: Promise<void>;
 
-    expect(all([])).toEqualTypeOf(Promise.all([]));
-    expect(all([value])).toEqualTypeOf(Promise.all([value]));
-    expect(all([task])).toEqualTypeOf(Promise.all([task]));
-    expect(all([thenable])).toEqualTypeOf(Promise.all([thenable]));
-    expect(all([promise])).toEqualTypeOf(Promise.all([promise]));
+    expect(all([])).resolves.toEqualTypeOf<[]>();
+    expect(all([value])).resolves.toEqualTypeOf<[string]>();
+    expect(all([task])).resolves.toEqualTypeOf<[boolean]>();
+    expect(all([thenable])).resolves.toEqualTypeOf<[number]>();
+    expect(all([promise])).resolves.toEqualTypeOf<[void]>();
 
     expect(
       all([value, task, thenable, promise])
-    ).toEqualTypeOf(
-      Promise.all([value, task, thenable, promise])
-    );
+    ).resolves.toEqualTypeOf<[string, boolean, number, void]>();
 
     {
       let result = await all([]);
@@ -1575,19 +1573,17 @@ module('unit tests', () => {
     let thenable!: PromiseLike<number>;
     let promise!: Promise<void>;
 
-    expect(allSettled([])).toEqualTypeOf(Promise.allSettled([]));
-    expect(allSettled([value])).toEqualTypeOf(Promise.allSettled([value]));
-    expect(allSettled([task])).toEqualTypeOf(Promise.allSettled([task]));
-    expect(allSettled([thenable])).toEqualTypeOf(Promise.allSettled([thenable]));
-    expect(allSettled([promise])).toEqualTypeOf(Promise.allSettled([promise]));
+    type S<T> = { state: 'fulfilled', value: T } | { state: 'rejected', reason: any };
+
+    expect(allSettled([])).resolves.toEqualTypeOf<[]>();
+    expect(allSettled([value])).resolves.toEqualTypeOf<[S<string>]>();
+    expect(allSettled([task])).resolves.toEqualTypeOf<[S<boolean>]>();
+    expect(allSettled([thenable])).resolves.toEqualTypeOf<[S<number>]>();
+    expect(allSettled([promise])).resolves.toEqualTypeOf<[S<void>]>();
 
     expect(
       allSettled([value, task, thenable, promise])
-    ).toEqualTypeOf(
-      Promise.allSettled([value, task, thenable, promise])
-    );
-
-    type S<T> = { state: 'fulfilled', value: T } | { state: 'rejected', reason: any };
+    ).resolves.toEqualTypeOf<[S<string>, S<boolean>, S<number>, S<void>]>();
 
     {
       let result = await allSettled([]);


### PR DESCRIPTION
This feature unfortunately depends on private APIs that will be removed in Ember 3.25. Unfortunately, the mechanism was already removed in Ember 3.20, making it impossible to support this for releases at least until recent canaries where it was re-introduced with a deprecation. However, the feature is rarely used, only documented in the changelog, and frequently breaks whenever the private constant it depends on moves modules internally throughout new versions of Ember.

It will continue to remain available for Ember < 3.20, but will not be available in Ember-Concurrency 2.0, and will show a deprecation warning from 1.3.0 forward.

Also, fixes the failing TypeScript tests, affecting other in-progress PRs #365 & #368 