### PR TITLE
v2: native class encapsulated tasks

### DIFF
--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -16,17 +16,25 @@ export type TaskForTaskFunction<T extends TaskFunction<any, any[]>> =
 export type TaskInstanceForTaskFunction<T extends TaskFunction<any, any[]>> =
   TaskInstance<TaskFunctionReturnType<T>>;
 
-export interface EncapsulatedTaskDescriptor<T, Args extends any[]> {
+interface EncapsulatedTaskLike<T, Args extends any[]> {
   perform(...args: Args): TaskGenerator<T>;
 }
 
+export type EncapsulatedTaskDescriptor<T, Args extends any[]> =
+  EncapsulatedTaskLike<T, Args> | (new () => EncapsulatedTaskLike<T, Args>);
+
 export type EncapsulatedTaskDescriptorArgs<T extends EncapsulatedTaskDescriptor<any, any[]>> =
-  T extends { perform(...args: infer A): TaskGenerator<any> } ? A : [];
+  T extends EncapsulatedTaskDescriptor<any, infer A> ? A : [];
 
 export type EncapsulatedTaskDescriptorReturnType<T extends EncapsulatedTaskDescriptor<any, any[]>> =
-  T extends { perform(...args: any[]): TaskGenerator<infer R> } ? R : unknown;
+  T extends EncapsulatedTaskDescriptor<infer R, any[]> ? R : unknown;
 
-export type EncapsulatedTaskState<T extends object> = Omit<T, 'perform' | keyof TaskInstance<any>>;
+type EncapsulatedTaskStateProps<T> = Omit<T, keyof EncapsulatedTaskLike<T, any[]> | keyof TaskInstance<any>>;
+
+export type EncapsulatedTaskState<T> =
+  T extends (new () => infer R)
+  ? EncapsulatedTaskStateProps<R>
+  : (T extends object ? EncapsulatedTaskStateProps<T> : unknown);
 
 export type TaskForEncapsulatedTaskDescriptor<T extends EncapsulatedTaskDescriptor<any, any[]>> =
   EncapsulatedTask<

--- a/tests/unit/encapsulated-task-test.js
+++ b/tests/unit/encapsulated-task-test.js
@@ -1,11 +1,16 @@
 import { run } from '@ember/runloop';
 import RSVP from 'rsvp';
+import { setOwner } from '@ember/application';
 import EmberObject from '@ember/object';
+import Service, { inject as service } from '@ember/service';
 import { task } from 'ember-concurrency';
 import { gte } from 'ember-compatibility-helpers';
 import { module, test } from 'qunit';
+import { setupTest } from 'ember-qunit';
 
-module('Unit: EncapsulatedTask', function() {
+module('Unit: EncapsulatedTask', function(hooks) {
+  setupTest(hooks);
+
   test("tasks can be specified via a pojos with perform methods", function(assert) {
     assert.expect(2);
 
@@ -52,6 +57,84 @@ module('Unit: EncapsulatedTask', function() {
       run(() => {
         obj = new FakeGlimmerComponent();
         obj.myTask.perform(1,2,3).then(v => {
+          assert.equal(v, 123);
+        });
+      });
+      run(defer, 'resolve');
+    });
+
+    test("tasks can be specified via a native classes with perform methods", function(assert) {
+      assert.expect(3);
+
+      let defer, serviceCalled;
+
+      this.owner.register('service:test-service', Service.extend({
+        call() {
+          serviceCalled = true;
+        }
+      }));
+
+      class MyCoolEncapsulatedTaskClass {
+        @service testService;
+
+        *perform(...args) {
+          assert.deepEqual(args, [1,2,3]);
+          defer = RSVP.defer();
+          yield defer.promise;
+          this.testService.call();
+          return 123;
+        }
+      }
+
+      class FakeGlimmerComponent {
+        @(task(MyCoolEncapsulatedTaskClass)) myTask;
+      }
+
+      let obj;
+      run(() => {
+        obj = new FakeGlimmerComponent();
+        setOwner(obj, this.owner);
+
+        obj.myTask.perform(1,2,3).then(v => {
+          assert.ok(serviceCalled, 'expected service method to have been called');
+          assert.equal(v, 123);
+        });
+      });
+      run(defer, 'resolve');
+    });
+
+    test("tasks can be specified via an anonymous native class with perform method", function(assert) {
+      assert.expect(3);
+
+      let defer, serviceCalled;
+
+      this.owner.register('service:test-service', Service.extend({
+        call() {
+          serviceCalled = true;
+        }
+      }));
+
+      class FakeGlimmerComponent {
+        @(task(class {
+          @service testService;
+
+          *perform(...args) {
+            assert.deepEqual(args, [1,2,3]);
+            defer = RSVP.defer();
+            yield defer.promise;
+            this.testService.call();
+            return 123;
+          }
+        })) myTask;
+      }
+
+      let obj;
+      run(() => {
+        obj = new FakeGlimmerComponent();
+        setOwner(obj, this.owner);
+
+        obj.myTask.perform(1,2,3).then(v => {
+          assert.ok(serviceCalled, 'expected service method to have been called');
           assert.equal(v, 123);
         });
       });


### PR DESCRIPTION
This enables using native classes w/ encapsulated tasks, enabling some cool re-use cases.

e.g.

```javascript
// app/tasks/mapping
export default class FindMeTask {
  @service geolocation;

  *perform() {
     // ... some geolocation magic ...
  }
}
```

```javascript
// app/components/local-map-or-whatever.js
import FindMeTask from 'my-app/tasks/find-me';
import { task } from 'ember-concurrency';
// ... other imports

export default class LocalMapOrWhatever extends GlimmerComponent {
  @(task(FindMeTask).restartable()) findMe;

  // ... other stuff
}
```