### PR TITLE
docs: Replace cancelOn with cancelAll in route-tasks

### DIFF
--- a/tests/dummy/app/docs/examples/route-tasks/template.hbs
+++ b/tests/dummy/app/docs/examples/route-tasks/template.hbs
@@ -49,8 +49,8 @@
     performs the task, any prior instances are canceled.
   </li>
   <li>
-    We use <code>.cancelOn('deactivate')</code> to make sure the task cancels
-    when the user leaves the route.
+    We use <code>cancelAll</code> in the route's <code>resetController</code>
+    hook to make sure the task cancels when the user leaves the route.
   </li>
 </ul>
 


### PR DESCRIPTION
Small docs change. PR https://github.com/machty/ember-concurrency/pull/317 changed the `detail-route.js` snippet but didn't update the corresponding section of the docs. This is that snippet:

https://github.com/machty/ember-concurrency/blob/2be69e87280e7302c0ccfbb21b3884bc04db376f/tests/dummy/app/docs/examples/route-tasks/detail/route.js#L5-L34