### PR TITLE
v2: Make sure task/group-level state field is tracked

### DIFF
--- a/addon/-private/external/task/taskable.js
+++ b/addon/-private/external/task/taskable.js
@@ -49,4 +49,5 @@ Object.assign(Taskable.prototype, {
   isRunning: false,
   isQueued: false,
   isIdle: true,
+  state: 'idle'
 });

--- a/addon/-private/tracked-state.js
+++ b/addon/-private/tracked-state.js
@@ -33,6 +33,7 @@ if (USE_TRACKED) {
     isRunning: false,
     isQueued: false,
     isIdle: true,
+    state: 'idle'
   }, TRACKED_INITIAL_TASK_STATE);
 
   TRACKED_INITIAL_INSTANCE_STATE = applyTracked(INITIAL_INSTANCE_STATE, {});

--- a/tests/unit/task-groups-test.js
+++ b/tests/unit/task-groups-test.js
@@ -10,10 +10,11 @@ module('Unit: task groups', function() {
     assert.equal(task.isRunning, isRunning, `${task._propertyName} is ${isRunning ? '' : 'not'} running ${suffix}`);
     assert.equal(task.isQueued,  isQueued,  `${task._propertyName} is ${isQueued ? '' : 'not'} queued ${suffix}`);
     assert.equal(task.isIdle,    isIdle,    `${task._propertyName} is ${isIdle ? '' : 'not'} idle ${suffix}`);
+    assert.equal(task.state, isRunning ? 'running' : 'idle', `${task._propertyName} state is '${isRunning ? 'running' : 'idle'}' ${suffix}`)
   }
 
   test("task groups allow tasks to share concurrency constraints", function(assert) {
-    assert.expect(48);
+    assert.expect(63);
 
     let deferA, deferB;
     let Obj = EmberObject.extend({
@@ -115,7 +116,7 @@ module('Unit: task groups', function() {
   }
 
   test("enqueued task groups can be canceled", function(assert) {
-    assert.expect(18);
+    assert.expect(24);
 
     let [taskA, taskB, tg] = sharedTaskGroupSetup(taskGroup().enqueue());
     let suffix = "after first run loop";
@@ -133,7 +134,7 @@ module('Unit: task groups', function() {
   });
 
   test("unmodified task groups can be canceled", function(assert) {
-    assert.expect(18);
+    assert.expect(24);
 
     let [taskA, taskB, tg] = sharedTaskGroupSetup(taskGroup());
     let suffix = "after first run loop";
@@ -212,7 +213,7 @@ module('Unit: task groups', function() {
 
   if (gte('3.10.0')) {
     test("ES class syntax with decorators works with task groups", function(assert) {
-      assert.expect(9);
+      assert.expect(12);
 
       let deferA, deferB;
       class FakeGlimmerComponent {


### PR DESCRIPTION
state on Task or TaskGroup indicates whether the task is
running or idle. We were setting this properly, but the
underlying property wasn't tracked, rendering it useless
in the template (breaking some docs pages)