### PR TITLE
Fix encapsulated state render updates

### DIFF
--- a/tests/acceptance/task-injection-test.js
+++ b/tests/acceptance/task-injection-test.js
@@ -6,13 +6,14 @@ module('Acceptance | injections on encapsulated tests', function(hooks) {
   setupApplicationTest(hooks);
 
   test('encapsulated tasks support injections', async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     await visit('/task-injection-test');
 
-    let buttonSel = `[data-test-selector="perform-task-w-injection-button"]`;
-
-    await click(buttonSel);
+    await click(`[data-test-selector="perform-task-w-injection-button"]`);
     assert.dom(`[data-test-selector="perform-task-result"]`).hasText('123-246');
+
+    await click(`[data-test-selector="perform-task-w-injection-button-part-2"]`);
+    assert.dom(`[data-test-selector="perform-task-result"]`).hasText('123-456');
   });
 });

--- a/tests/dummy/app/task-injection-test/controller.js
+++ b/tests/dummy/app/task-injection-test/controller.js
@@ -7,16 +7,20 @@ export default Controller.extend({
 
   myTask: task({
     fun: service(),
-    *perform() {
-      let value = yield this.subtask.perform();
+    *perform(suffix) {
+      let value = yield this.subtask.perform(suffix);
       return `${this.get('fun.foo')}-${value}`;
     },
 
     subtask: task({
       fun: service(),
       wat: 2,
-      *perform() {
-        return this.get('fun.foo') * this.wat;
+      *perform(suffix) {
+        if (suffix) {
+          return suffix;
+        } else {
+          return this.get('fun.foo') * this.wat;
+        }
       },
     }),
   }),

--- a/tests/dummy/app/task-injection-test/template.hbs
+++ b/tests/dummy/app/task-injection-test/template.hbs
@@ -1,5 +1,11 @@
 <h1>Task injection test</h1>
 
-<button onclick={{perform this.myTask}} data-test-selector="perform-task-w-injection-button" type="button">clickme</button>
+<button onclick={{perform this.myTask null}}
+  data-test-selector="perform-task-w-injection-button"
+  type="button">clickme</button>
+
+<button onclick={{perform this.myTask '456'}}
+  data-test-selector="perform-task-w-injection-button-part-2"
+  type="button">another one</button>
 
 <p data-test-selector="perform-task-result">{{this.myTask.last.value}}</p>


### PR DESCRIPTION
This one is a bit in-the-weeds, but it's effectively
a bugfix plus a workaround for < 3.16. We're now wrapping
TaskInstance internally and externally for EncapsulatedTask
launched instances. This is so that internal state updates
work. However, for Ember < 3.16, we needed to go a step
further and add some additional handlers to the Proxy setup
in order to ensure derived state updates get rendered
correctly, due to the way the state was stored in those
versions.