### PR TITLE
v2: Provide nice decorators via ember-concurrency-decorators

### DIFF
--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -1,5 +1,5 @@
 import { Task } from './-private/task';
-import { TaskProperty } from './-private/computed-properties';
+import { TaskProperty } from './-private/task-properties';
 import { deprecatePrivateModule } from './-private/utils';
 deprecatePrivateModule("ember-concurrency/-task-property");
 export { Task, TaskProperty };

--- a/addon/index.js
+++ b/addon/index.js
@@ -4,7 +4,7 @@ import {
   TaskGroupProperty,
   task,
   taskGroup
-} from './-private/computed-properties';
+} from './-private/task-properties';
 import { default as TaskInstance } from './-private/task-instance';
 import {
   all,
@@ -26,6 +26,18 @@ import {
 } from './-private/external/yieldables';
 import { Task } from './-private/task';
 import { TaskGroup } from './-private/task-group';
+
+// Re-export e-c-d, until we merge it.
+export {
+  restartableTask,
+  dropTask,
+  keepLatestTask,
+  enqueueTask,
+  restartableTaskGroup,
+  dropTaskGroup,
+  keepLatestTaskGroup,
+  enqueueTaskGroup
+} from 'ember-concurrency-decorators';
 
 export {
   task,

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "experimentalDecorators": true
+  },
+  "exclude": [
+    "node_modules",
+    "bower_components",
+    "tmp",
+    "vendor",
+    ".git",
+    "dist"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ember-cli-terser": "^4.0.0",
     "ember-code-snippet": "^2.4.0",
     "ember-concurrency-async": "^0.2.1",
-    "ember-concurrency-decorators": "^2.0.0",
     "ember-concurrency-ts": "^0.1.1",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-disable-proxy-controllers": "^1.0.1",
@@ -94,6 +93,7 @@
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-compatibility-helpers": "^1.2.0",
+    "ember-concurrency-decorators": "^2.0.0",
     "ember-destroyable-polyfill": "^2.0.2"
   },
   "ember": {

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -1,4 +1,8 @@
+import { skip, test } from "qunit";
+import { gte } from "ember-compatibility-helpers";
 import Ember from 'ember';
+
+export const decoratorTest = gte('3.10.0') ? test : skip;
 
 export function makeAsyncError(hooks) {
   hooks.afterEach(() => Ember.onerror = null);

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -31,6 +31,7 @@ import {
   hashSettled,
   race,
   rawTimeout,
+  restartableTask,
   task,
   taskGroup,
   timeout,
@@ -38,7 +39,6 @@ import {
   waitForProperty,
   waitForQueue
 } from 'ember-concurrency';
-import { restartableTask } from 'ember-concurrency-decorators';
 import { taskFor } from 'ember-concurrency-ts';
 import { expectTypeOf as expect } from 'expect-type';
 
@@ -2378,6 +2378,20 @@ module('integration tests', () => {
   test('octane', () => {
     class MyComponent extends GlimmerComponent {
       declare foo: string;
+
+      @task({ restartable: true }) restartable = function*() {};
+      @task({ enqueue: true }) enqueue = function*() {};
+      @task({ drop: true }) drop = function*() {};
+      @task({ keepLatest: true }) keepLatest = function*() {};
+      @task({ evented: true }) evented = function*() {};
+      @task({ debug: true }) debug = function*() {};
+
+      // Note: these options work even when strictFunctionTypes is enabled, but
+      // turning it on in this repo breaks other things in addon/index.d.ts
+      @task({ on: 'hi' }) on = function*() {};
+      @task({ cancelOn: 'bye' }) cancelOn = function*() {};
+      @task({ maxConcurrency: 1 }) maxConcurrency = function*() {};
+      @task({ group: 'foo' }) group = function*() {};
 
       @restartableTask *myTask(immediately: boolean, ms: number = 500): TaskGenerator<string> {
         // We want to assert `this` is not implicitly `any`, but due `this`

--- a/tests/unit/decorators-test.js
+++ b/tests/unit/decorators-test.js
@@ -1,0 +1,89 @@
+import { module } from "qunit";
+import { run } from "@ember/runloop";
+import { setOwner } from "@ember/application";
+import {
+  task,
+  restartableTask,
+  dropTask,
+  keepLatestTask,
+  enqueueTask,
+} from "ember-concurrency";
+import { decoratorTest } from '../helpers/helpers';
+
+module("Unit | decorators", function () {
+  decoratorTest("Basic decorators functionality", function (assert) {
+    assert.expect(5);
+
+    class TestSubject {
+      @task doStuff = function* () {
+        yield;
+        return 123;
+      };
+
+      @restartableTask
+      a = function* () {
+        yield;
+        return 456;
+      };
+
+      @keepLatestTask
+      b = function* () {
+        yield;
+        return 789;
+      };
+
+      @dropTask
+      c = function* () {
+        yield;
+        return 12;
+      };
+
+      @enqueueTask
+      d = function* () {
+        yield;
+        return 34;
+      };
+    }
+
+    let subject;
+    run(() => {
+      subject = new TestSubject();
+
+      setOwner(subject, this.owner);
+
+      subject.doStuff.perform();
+      subject.a.perform();
+      subject.b.perform();
+      subject.c.perform();
+      subject.d.perform();
+    });
+
+    assert.equal(subject.doStuff.last.value, 123);
+    assert.equal(subject.a.last.value, 456);
+    assert.equal(subject.b.last.value, 789);
+    assert.equal(subject.c.last.value, 12);
+    assert.equal(subject.d.last.value, 34);
+  });
+
+  decoratorTest("Encapsulated tasks", function (assert) {
+    assert.expect(1);
+
+    class TestSubject {
+      @task encapsulated = {
+        privateState: 56,
+        *perform() {
+          yield;
+          return this.privateState;
+        },
+      };
+    }
+
+    let subject;
+    run(() => {
+      subject = new TestSubject();
+      setOwner(subject, this.owner);
+      subject.encapsulated.perform();
+    });
+    assert.equal(subject.encapsulated.last.value, 56);
+  });
+});

--- a/tests/unit/encapsulated-task-test.js
+++ b/tests/unit/encapsulated-task-test.js
@@ -2,8 +2,8 @@ import { run } from '@ember/runloop';
 import RSVP from 'rsvp';
 import EmberObject from '@ember/object';
 import { task } from 'ember-concurrency';
-import { gte } from 'ember-compatibility-helpers';
 import { module, test } from 'qunit';
+import { decoratorTest } from '../helpers/helpers';
 
 module('Unit: EncapsulatedTask', function() {
   test("tasks can be specified via a pojos with perform methods", function(assert) {
@@ -56,31 +56,29 @@ module('Unit: EncapsulatedTask', function() {
     assert.equal(taskInstance.someProp, true);
   });
 
-  if (gte('3.10.0')) {
-    test("encapsulated tasks work with native ES classes and decorators", function(assert) {
-      assert.expect(2);
+  decoratorTest("encapsulated tasks work with native ES classes and decorators", function(assert) {
+    assert.expect(2);
 
-      let defer;
+    let defer;
 
-      class FakeGlimmerComponent {
-        @(task({
-          *perform(...args) {
-            assert.deepEqual(args, [1,2,3]);
-            defer = RSVP.defer();
-            yield defer.promise;
-            return 123;
-          }
-        })) myTask;
-      }
+    class FakeGlimmerComponent {
+      @task myTask = {
+        *perform(...args) {
+          assert.deepEqual(args, [1,2,3]);
+          defer = RSVP.defer();
+          yield defer.promise;
+          return 123;
+        }
+      };
+    }
 
-      let obj;
-      run(() => {
-        obj = new FakeGlimmerComponent();
-        obj.myTask.perform(1,2,3).then(v => {
-          assert.equal(v, 123);
-        });
+    let obj;
+    run(() => {
+      obj = new FakeGlimmerComponent();
+      obj.myTask.perform(1,2,3).then(v => {
+        assert.equal(v, 123);
       });
-      run(defer, 'resolve');
     });
-  }
+    run(defer, 'resolve');
+  });
 });

--- a/tests/unit/generator-method-test.js
+++ b/tests/unit/generator-method-test.js
@@ -1,0 +1,63 @@
+import { module } from 'qunit';
+import { run } from '@ember/runloop';
+import {
+  task,
+  restartableTask,
+  dropTask,
+  keepLatestTask,
+  enqueueTask
+} from 'ember-concurrency';
+import { decoratorTest } from '../helpers/helpers';
+
+module('Unit | generator method', function() {
+  decoratorTest('Basic decorators functionality', function(assert) {
+    assert.expect(5);
+
+    class TestSubject {
+      @task
+      *doStuff() {
+        yield;
+        return 123;
+      }
+
+      @restartableTask
+      *a() {
+        yield;
+        return 456;
+      }
+
+      @keepLatestTask
+      *b() {
+        yield;
+        return 789;
+      }
+
+      @dropTask
+      *c() {
+        yield;
+        return 12;
+      }
+
+      @enqueueTask
+      *d() {
+        yield;
+        return 34;
+      }
+    }
+
+    let subject;
+    run(() => {
+      subject = new TestSubject();
+      subject.doStuff.perform();
+      subject.a.perform();
+      subject.b.perform();
+      subject.c.perform();
+      subject.d.perform();
+    });
+    assert.equal(subject.doStuff.last.value, 123);
+    assert.equal(subject.a.last.value, 456);
+    assert.equal(subject.b.last.value, 789);
+    assert.equal(subject.c.last.value, 12);
+    assert.equal(subject.d.last.value, 34);
+  });
+});

--- a/tests/unit/task-groups-test.js
+++ b/tests/unit/task-groups-test.js
@@ -2,8 +2,8 @@ import { run } from '@ember/runloop';
 import RSVP from 'rsvp';
 import EmberObject from '@ember/object';
 import { task, taskGroup, forever } from 'ember-concurrency';
-import { gte } from 'ember-compatibility-helpers';
 import { module, test } from 'qunit';
+import { decoratorTest } from '../helpers/helpers';
 
 module('Unit: task groups', function() {
   function assertStates(assert, task, isRunning, isQueued, isIdle, suffix) {
@@ -211,40 +211,38 @@ module('Unit: task groups', function() {
     assertRunning();
   });
 
-  if (gte('3.10.0')) {
-    test("ES class syntax with decorators works with task groups", function(assert) {
-      assert.expect(12);
+  decoratorTest("ES class syntax with decorators works with task groups", function(assert) {
+    assert.expect(12);
 
-      let deferA, deferB;
-      class FakeGlimmerComponent {
-        @(taskGroup().enqueue()) tg;
+    let deferA, deferB;
+    class FakeGlimmerComponent {
+      @taskGroup({ enqueue: true }) tg;
 
-        @(task(function * () {
-          deferA = RSVP.defer();
-          yield deferA.promise;
-        }).group('tg')) taskA;
-
-        @(task(function * () {
-          deferB = RSVP.defer();
-          yield deferB.promise;
-        }).group('tg')) taskB;
+      @task({ group: 'tg' }) *taskA() {
+        deferA = RSVP.defer();
+        yield deferA.promise;
       }
 
-      let obj, taskA, taskB, suffix, tg;
+      @task({ group: 'tg' }) *taskB() {
+        deferB = RSVP.defer();
+        yield deferB.promise;
+      }
+    }
 
-      run(() => {
-        obj = new FakeGlimmerComponent();
-        tg = obj.tg;
-        taskA = obj.taskA;
-        taskB = obj.taskB;
+    let obj, taskA, taskB, suffix, tg;
 
-        taskA.perform();
-      });
+    run(() => {
+      obj = new FakeGlimmerComponent();
+      tg = obj.tg;
+      taskA = obj.taskA;
+      taskB = obj.taskB;
 
-      suffix = "performing taskA";
-      assertStates(assert, tg,    true, false, false, suffix);
-      assertStates(assert, taskA, true, false, false, suffix);
-      assertStates(assert, taskB, false, false, true, suffix);
+      taskA.perform();
     });
-  }
+
+    suffix = "performing taskA";
+    assertStates(assert, tg,    true, false, false, suffix);
+    assertStates(assert, taskA, true, false, false, suffix);
+    assertStates(assert, taskB, false, false, true, suffix);
+  });
 });

--- a/tests/unit/wait-for-test.js
+++ b/tests/unit/wait-for-test.js
@@ -11,7 +11,7 @@ import {
   race
 } from 'ember-concurrency';
 import { alias } from '@ember/object/computed';
-import { gte } from 'ember-compatibility-helpers';
+import { decoratorTest } from '../helpers/helpers';
 
 const EventedObject = EmberObject.extend(Evented);
 
@@ -420,41 +420,39 @@ module('Unit: test waitForQueue and waitForEvent and waitForProperty', function(
     assert.equal(ev, 456);
   });
 
-  if (gte('3.10.0')) {
-    test('waitForProperty works on an ES class', async function(assert) {
-      assert.expect(1);
+  decoratorTest('waitForProperty works on an ES class', async function(assert) {
+    assert.expect(1);
 
-      let values = [];
-      class Obj {
-        a = 1;
+    let values = [];
+    class Obj {
+      a = 1;
 
-        @computed('a')
-        get b() {
-          return this.a;
-        }
-
-        @(task(function*() {
-          let result = yield waitForProperty(this, 'b', v => {
-            values.push(v);
-            return v == 3 ? 'done' : false;
-          });
-          values.push(`val=${result}`);
-        })) task;
+      @computed('a')
+      get b() {
+        return this.a;
       }
 
-      let obj = new Obj();
-      obj.task.perform();
+      @(task(function*() {
+        let result = yield waitForProperty(this, 'b', v => {
+          values.push(v);
+          return v == 3 ? 'done' : false;
+        });
+        values.push(`val=${result}`);
+      })) task;
+    }
 
-      set(obj, 'a', 2);
-      await settled();
+    let obj = new Obj();
+    obj.task.perform();
 
-      set(obj, 'a', 3);
-      await settled();
+    set(obj, 'a', 2);
+    await settled();
 
-      set(obj, 'a', 4);
-      await settled();
+    set(obj, 'a', 3);
+    await settled();
 
-      assert.deepEqual(values, [1, 2, 3, 'val=3']);
-    });
-  }
+    set(obj, 'a', 4);
+    await settled();
+
+    assert.deepEqual(values, [1, 2, 3, 'val=3']);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es6",
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,


### PR DESCRIPTION
This sets up some foundational work to begin combining [`ember-concurrency-decorators`](https://github.com/machty/ember-concurrency-decorators), by directly depending upon the current addon but without requiring separate import statements (or a separate dependency in a consuming app or addon's `package.json`)

It pulls in some base types for decoration options, and delegates the aliases for now to ember-concurrency-decorators. It also clones the decorator tests.

The "ugly" decorators (e.g. `(@(task(function* () { ... }).drop())` will remain available by virtue of coming "for free" with the computed-based TaskProperty implementation (necessary to support the classic EmberObject model for task hosts), but will be deprecated in favor these "nice" decorators.

A follow-up PR will convert all the docs to using the "nice" decorators.

A future PR (possibly post a final v2.0.0 release) will seek to fully integrate the "nice" decorators and remove the dependence on `computed` to provide decorator support for Ember versions that do not require it.