### PR TITLE
v2: Integrate "nice" decorators from ember-concurrency-decorators

### DIFF
--- a/addon/-private/task-decorators.js
+++ b/addon/-private/task-decorators.js
@@ -1,0 +1,165 @@
+import { computed, get } from '@ember/object';
+import { TaskFactory, TaskGroupFactory } from './task-factory';
+import { USE_TRACKED } from './utils';
+
+function taskFromPropertyDescriptor(target, key, descriptor, params = []) {
+  let { initializer, get, value } = descriptor;
+  let taskFn;
+
+  if (initializer) {
+    taskFn = initializer.call(undefined);
+  } else if (get) {
+    taskFn = get.call(undefined);
+  } else if (value) {
+    taskFn = value;
+  }
+
+  taskFn.displayName = `${key} (task)`;
+
+  let tasks = new WeakMap();
+  let options = params[0] || {};
+  let factory = new TaskFactory(key, taskFn, options);
+  factory._setupEmberKVO(target);
+
+  return {
+    get() {
+      let task = tasks.get(this);
+
+      if (!task) {
+        task = factory.createTask(this);
+        tasks.set(this, task);
+      }
+
+      return task;
+    }
+  }
+}
+
+function taskGroupPropertyDescriptor(target, key, _descriptor, params = []) {
+  let taskGroups = new WeakMap();
+  let options = params[0] || {};
+  let factory = new TaskGroupFactory(key, null, options);
+
+  return {
+    get() {
+      let task = taskGroups.get(this);
+
+      if (!task) {
+        task = factory.createTaskGroup(this);
+        taskGroups.set(this, task);
+      }
+
+      return task;
+    }
+  }
+}
+
+// Cribbed from @ember-decorators/utils
+function isFieldDescriptor(possibleDesc) {
+  let [target, key, desc] = possibleDesc;
+
+  return (
+    possibleDesc.length === 3 &&
+    typeof target === 'object' &&
+    target !== null &&
+    typeof key === 'string' &&
+    ((typeof desc === 'object' &&
+      desc !== null &&
+      'enumerable' in desc &&
+      'configurable' in desc) ||
+      desc === undefined) // TS compatibility ???
+  );
+}
+
+function decoratorWithParams(descriptorFn) {
+  return function(...params) {
+    if (isFieldDescriptor(params)) {
+      return descriptorFn(...params);
+    } else {
+      return (...desc) => descriptorFn(...desc, params);
+    }
+  }
+}
+
+function createDecorator(fn, baseOptions = {}) {
+  return decoratorWithParams((target, key, descriptor, [userOptions] = []) => {
+    let mergedOptions = Object.assign({}, { ...baseOptions, ...userOptions });
+
+    return fn(target, key, descriptor, [mergedOptions]);
+  });
+}
+
+export const lastValue = decoratorWithParams((target, key, descriptor, [taskName] = []) => {
+  const { initializer } = descriptor;
+  delete descriptor.initializer;
+
+  if (USE_TRACKED) {
+    return {
+      get() {
+        let lastInstance = this[taskName].lastSuccessful;
+
+        if (lastInstance) {
+          return lastInstance.value;
+        }
+
+        if (initializer) {
+          return initializer.call(this);
+        }
+
+        return undefined;
+      }
+    };
+  } else {
+    let cp = computed(`${taskName}.lastSuccessful`, function() {
+      let lastInstance = get(this, `${taskName}.lastSuccessful`);
+
+      if (lastInstance) {
+        return get(lastInstance, 'value');
+      }
+
+      if (initializer) {
+        return initializer.call(this);
+      }
+
+      return undefined;
+    });
+
+    return cp(target, key, descriptor);
+  }
+});
+
+export const task = createDecorator(taskFromPropertyDescriptor);
+export const dropTask = createDecorator(
+  taskFromPropertyDescriptor,
+  { drop: true }
+);
+export const enqueueTask = createDecorator(
+  taskFromPropertyDescriptor,
+  { enqueue: true }
+);
+export const keepLatestTask = createDecorator(
+  taskFromPropertyDescriptor,
+  { keepLatest: true }
+);
+export const restartableTask = createDecorator(
+  taskFromPropertyDescriptor,
+  { restartable: true }
+);
+
+export const taskGroup = createDecorator(taskGroupPropertyDescriptor);
+export const dropTaskGroup = createDecorator(
+  taskGroupPropertyDescriptor,
+  { drop: true }
+);
+export const enqueueTaskGroup = createDecorator(
+  taskGroupPropertyDescriptor,
+  { enqueue: true }
+);
+export const keepLatestTaskGroup = createDecorator(
+  taskGroupPropertyDescriptor,
+  { keepLatest: true }
+);
+export const restartableTaskGroup = createDecorator(
+  taskGroupPropertyDescriptor,
+  { restartable: true }
+);

--- a/addon/-private/task-factory.js
+++ b/addon/-private/task-factory.js
@@ -1,0 +1,186 @@
+import UnboundedSchedulerPolicy from './external/scheduler/policies/unbounded-policy';
+import EnqueueSchedulerPolicy from './external/scheduler/policies/enqueued-policy';
+import DropSchedulerPolicy from './external/scheduler/policies/drop-policy';
+import KeepLatestSchedulerPolicy from './external/scheduler/policies/keep-latest-policy';
+import RestartableSchedulerPolicy from './external/scheduler/policies/restartable-policy';
+
+import { assert } from '@ember/debug';
+import { Task, EncapsulatedTask } from './task';
+import { TaskGroup } from './task-group';
+import EmberScheduler from './scheduler/ember-scheduler';
+
+function assertModifiersNotMixedWithGroup(obj) {
+  assert(`ember-concurrency does not currently support using both 'group' with other task modifiers (e.g. 'drop', 'enqueue', 'restartable')`, !obj._hasUsedModifier || !obj._taskGroupPath);
+}
+
+function assertUnsetBufferPolicy(obj) {
+  assert(`Cannot set multiple buffer policies on a task or task group. ${obj._schedulerPolicyClass} has already been set for task or task group '${obj.name}'`, !obj._hasSetBufferPolicy);
+}
+
+export class TaskFactory {
+  _debug = null;
+  _hasUsedModifier = false;
+  _hasSetBufferPolicy = false;
+  _hasEnabledEvents = false;
+  _maxConcurrency = null;
+  _onStateCallback = (state, taskable) => taskable.setState(state);
+  _schedulerPolicyClass = UnboundedSchedulerPolicy;
+  _taskGroupPath = null;
+
+  constructor(ownerPrototype, name, taskDefinition = null, options = {}) {
+    this.ownerPrototype = ownerPrototype;
+    this.name = name;
+    this.taskDefinition = taskDefinition;
+
+    this._processOptions(options);
+  }
+
+  createTask(context) {
+    assert(`Cannot create task if a task definition is not provided as generator function or encapsulated task.`, this.taskDefinition);
+    let options = this._sharedTaskProperties(context);
+
+    if (typeof this.taskDefinition === 'object') {
+      return new EncapsulatedTask(
+        Object.assign({ taskObj: this.taskDefinition }, options)
+      );
+    } else {
+      return new Task(
+        Object.assign({
+          generatorFactory: (args) => this.taskDefinition.apply(context, args),
+        }, options)
+      );
+    }
+  }
+
+  setBufferPolicy(policy) {
+    assertUnsetBufferPolicy(this);
+    this._hasSetBufferPolicy = true;
+    this._hasUsedModifier = true;
+    this._schedulerPolicyClass = policy;
+    assertModifiersNotMixedWithGroup(this);
+
+    return this;
+  }
+
+  setDebug(debug) {
+    this._debug = debug;
+    return this;
+  }
+
+  setEvented(evented) {
+    this._hasEnabledEvents = evented;
+    return this;
+  }
+
+  setMaxConcurrency(maxConcurrency) {
+    assert(`maxConcurrency must be an integer (Task '${this.name}')`, Number.isInteger(maxConcurrency));
+    this._hasUsedModifier = true;
+    this._maxConcurrency = maxConcurrency;
+    assertModifiersNotMixedWithGroup(this);
+    return this;
+  }
+
+  setGroup(group) {
+    this._taskGroupPath = group;
+    assertModifiersNotMixedWithGroup(this);
+    return this;
+  }
+
+  setName(name) {
+    this.name = name;
+    return this;
+  }
+
+  setOnState(onStateCallback) {
+    this._onStateCallback = onStateCallback;
+    return this;
+  }
+
+  setTaskDefinition(taskDefinition) {
+    assert(
+      `Task definition must be a generator function or encapsulated task.`,
+      typeof taskDefinition === "function" || (
+        typeof taskDefinition === "object" &&
+        typeof taskDefinition.perform === "function"
+      )
+    );
+    this.taskDefinition = taskDefinition;
+    return this;
+  }
+
+  _processOptions(options) {
+    // TODO: Turn this into some kind of pipeline...
+
+    if (options.restartable) {
+      this.setBufferPolicy(RestartableSchedulerPolicy);
+    }
+
+    if (options.enqueue) {
+      this.setBufferPolicy(EnqueueSchedulerPolicy);
+    }
+
+    if (options.drop) {
+      this.setBufferPolicy(DropSchedulerPolicy);
+    }
+
+    if (options.keepLatest) {
+      this.setBufferPolicy(KeepLatestSchedulerPolicy);
+    }
+
+    if (options.maxConcurrency) {
+      this.setMaxConcurrency(options.maxConcurrency);
+    }
+
+    if (options.group) {
+      this.setGroup(options.group);
+    }
+
+    if (options.evented) {
+      this.setEvented(true);
+    }
+
+    if (options.debug) {
+      this.setDebug(true);
+    }
+
+    if (options.onState) {
+      this.setOnState(options.onState);
+    }
+  }
+
+  _sharedTaskProperties(context) {
+    let group, scheduler;
+    let onStateCallback = this._onStateCallback;
+
+    if (this._taskGroupPath) {
+      group = context[this._taskGroupPath];
+      assert(
+        `ember-concurrency: Expected group '${this._taskGroupPath}' to be defined but was not found.`,
+        group instanceof TaskGroup
+      );
+      scheduler = group.scheduler;
+    } else {
+      let schedulerPolicy = new this._schedulerPolicyClass(this._maxConcurrency);
+      scheduler = new EmberScheduler(schedulerPolicy, onStateCallback);
+    }
+
+    return {
+      context,
+      debug: this._debug,
+      name: this.name,
+      group,
+      scheduler,
+      hasEnabledEvents: this._hasEnabledEvents,
+      onStateCallback,
+    };
+  }
+}
+
+export class TaskGroupFactory extends TaskFactory {
+  createTaskGroup(context) {
+    assert(`A task definition is not expected for a task group.`, !this.taskDefinition);
+    let options = this._sharedTaskProperties(context);
+
+    return new TaskGroup(options);
+  }
+}

--- a/addon/-private/task-instance.js
+++ b/addon/-private/task-instance.js
@@ -74,7 +74,7 @@ export class TaskInstance extends BaseTaskInstance {
 
   getName() {
     if (!this.name) {
-      this.name = (this.task && this.task._propertyName) || "<unknown>";
+      this.name = (this.task && this.task.name) || "<unknown>";
     }
     return this.name;
   }
@@ -96,7 +96,7 @@ export class TaskInstance extends BaseTaskInstance {
     let taskInstance = this;
     let task = taskInstance.task;
     let host = task.context;
-    let eventNamespace = task && task._propertyName;
+    let eventNamespace = task && task.name;
 
     if (host && host.trigger && eventNamespace) {
       let [eventType, ...args] = allArgs;

--- a/addon/-task-property.js
+++ b/addon/-task-property.js
@@ -1,5 +1,5 @@
 import { Task } from './-private/task';
-import { TaskProperty } from './-private/computed-properties';
+import { TaskProperty } from './-private/task-properties';
 import { deprecatePrivateModule } from './-private/utils';
 deprecatePrivateModule("ember-concurrency/-task-property");
 export { Task, TaskProperty };

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -1,14 +1,3 @@
-export {
-  restartableTask,
-  dropTask,
-  keepLatestTask,
-  enqueueTask,
-  restartableTaskGroup,
-  dropTaskGroup,
-  keepLatestTaskGroup,
-  enqueueTaskGroup
-} from 'ember-concurrency-decorators';
-
 import ComputedProperty from '@ember/object/computed';
 
 export type TaskGenerator<T> = Generator<any, T, any>;
@@ -432,6 +421,13 @@ interface AbstractTaskProperty<T extends Task<any, any[]>> extends ComputedPrope
   cancelOn(...eventNames: string[]): this;
 
   /**
+   * This behaves like the {@linkcode TaskProperty#on task(...).on() modifier},
+   * but instead will cause the task to be performed if any of the
+   * specified properties on the parent object change.
+   */
+  observes(...keys: string[]): this;
+
+  /**
    * Configures the task to cancel old currently task instances
    * to make room for a new one to perform. Sets default
    * maxConcurrency to 1.
@@ -677,8 +673,13 @@ type OptionTypeFor<T, F> = F extends (...args: infer Args) => T
   : never;
 
 type TaskOptions = OptionsFor<TaskProperty<unknown, unknown[]>>;
-
 type TaskGroupOptions = OptionsFor<TaskGroupProperty<unknown>>;
+
+type MethodOrPropertyDecoratorWithParams<
+  Params extends unknown[]
+> = MethodDecorator &
+  PropertyDecorator &
+  ((...params: Params) => MethodDecorator & PropertyDecorator);
 
 /**
  * A Task is a cancelable, restartable, asynchronous operation that
@@ -716,15 +717,19 @@ type TaskGroupOptions = OptionsFor<TaskGroupProperty<unknown>>;
  *
  * @function
  * @param {object?} [options={}]
- * @return {TaskProperty}
+ * @return {Task}
  */
 export function task<T extends TaskOptions>(baseOptions?: T):
-  MethodDecorator & PropertyDecorator;
+  MethodOrPropertyDecoratorWithParams<[T]>;
 export function task<T>(
   target: Object,
   propertyKey: string,
-  descriptor?: TypedPropertyDescriptor<T>
-): TypedPropertyDescriptor<T> | void;
+  descriptor: TypedPropertyDescriptor<T>
+): TypedPropertyDescriptor<T>;
+export function task(
+  target: Object,
+  propertyKey: string
+): void;
 
 /**
  * A Task is a cancelable, restartable, asynchronous operation that
@@ -780,6 +785,170 @@ export function task<T extends EncapsulatedTaskDescriptor<any, any[]>>(taskFn: T
   >;
 
 /**
+ * Turns the decorated generator function into a task and applies the
+ * `drop` modifier.
+ *
+ * Optionally takes a hash of options that will be applied as modifiers to the
+ * task. For instance `maxConcurrency`, `on`, or `group`.
+ *
+ * You can also define an
+ * <a href="/docs/encapsulated-task">Encapsulated Task</a>
+ * by decorating an object that defines a `perform` generator
+ * method.
+ *
+ * ```js
+ * import Component from '@glimmer/component';
+ * import { task, dropTask } from 'ember-concurrency';
+ *
+ * class MyComponent extends Component {
+ *   @task
+ *   *plainTask() {}
+ *
+ *   @dropTask({ cancelOn: 'click' })
+ *   *myDropTask() {}
+ * }
+ * ```
+ *
+ * @function
+ * @param {object?} [options={}]
+ * @return {Task}
+ */
+export function dropTask<T extends TaskOptions>(baseOptions?: T):
+  MethodOrPropertyDecoratorWithParams<[T]>;
+export function dropTask<T>(
+  target: Object,
+  propertyKey: string,
+  descriptor: TypedPropertyDescriptor<T>
+): TypedPropertyDescriptor<T>;
+export function dropTask(
+  target: Object,
+  propertyKey: string
+): void;
+
+/**
+ * Turns the decorated generator function into a task and applies the
+ * `enqueue` modifier.
+ *
+ * Optionally takes a hash of options that will be applied as modifiers to the
+ * task. For instance `maxConcurrency`, `on`, or `group`.
+ *
+ * You can also define an
+ * <a href="/docs/encapsulated-task">Encapsulated Task</a>
+ * by decorating an object that defines a `perform` generator
+ * method.
+ *
+ * ```js
+ * import Component from '@glimmer/component';
+ * import { task, enqueueTask } from 'ember-concurrency';
+ *
+ * class MyComponent extends Component {
+ *   @task
+ *   *plainTask() {}
+ *
+ *   @enqueueTask({ cancelOn: 'click' })
+ *   *myEnqueueTask() {}
+ * }
+ * ```
+ *
+ * @function
+ * @param {object?} [options={}]
+ * @return {Task}
+ */
+export function enqueueTask<T extends TaskOptions>(baseOptions?: T):
+  MethodOrPropertyDecoratorWithParams<[T]>;
+export function enqueueTask<T>(
+  target: Object,
+  propertyKey: string,
+  descriptor: TypedPropertyDescriptor<T>
+): TypedPropertyDescriptor<T>;
+export function enqueueTask(
+  target: Object,
+  propertyKey: string
+): void;
+
+/**
+ * Turns the decorated generator function into a task and applies the
+ * `keepLatest` modifier.
+ *
+ * Optionally takes a hash of options that will be applied as modifiers to the
+ * task. For instance `maxConcurrency`, `on`, or `group`.
+ *
+ * You can also define an
+ * <a href="/docs/encapsulated-task">Encapsulated Task</a>
+ * by decorating an object that defines a `perform` generator
+ * method.
+ *
+ * ```js
+ * import Component from '@glimmer/component';
+ * import { task, keepLatestTask } from 'ember-concurrency';
+ *
+ * class MyComponent extends Component {
+ *   @task
+ *   *plainTask() {}
+ *
+ *   @keepLatestTask({ cancelOn: 'click' })
+ *   *myKeepLatestTask() {}
+ * }
+ * ```
+ *
+ * @function
+ * @param {object?} [options={}]
+ * @return {Task}
+ */
+export function keepLatestTask<T extends TaskOptions>(baseOptions?: T):
+  MethodOrPropertyDecoratorWithParams<[T]>;
+export function keepLatestTask<T>(
+  target: Object,
+  propertyKey: string,
+  descriptor: TypedPropertyDescriptor<T>
+): TypedPropertyDescriptor<T>;
+export function keepLatestTask(
+  target: Object,
+  propertyKey: string
+): void;
+
+/**
+ * Turns the decorated generator function into a task and applies the
+ * `restartable` modifier.
+ *
+ * Optionally takes a hash of options that will be applied as modifiers to the
+ * task. For instance `maxConcurrency`, `on`, or `group`.
+ *
+ * You can also define an
+ * <a href="/docs/encapsulated-task">Encapsulated Task</a>
+ * by decorating an object that defines a `perform` generator
+ * method.
+ *
+ * ```js
+ * import Component from '@glimmer/component';
+ * import { task, restartableTask } from 'ember-concurrency';
+ *
+ * class MyComponent extends Component {
+ *   @task
+ *   *plainTask() {}
+ *
+ *   @restartableTask({ cancelOn: 'click' })
+ *   *myRestartableTask() {}
+ * }
+ * ```
+ *
+ * @function
+ * @param {object?} [options={}]
+ * @return {Task}
+ */
+export function restartableTask<T extends TaskOptions>(baseOptions?: T):
+  MethodOrPropertyDecoratorWithParams<[T]>;
+export function restartableTask<T>(
+  target: Object,
+  propertyKey: string,
+  descriptor: TypedPropertyDescriptor<T>
+): TypedPropertyDescriptor<T>;
+export function restartableTask(
+  target: Object,
+  propertyKey: string
+): void;
+
+/**
  * "Task Groups" provide a means for applying
  * task modifiers to groups of tasks. Once a {@linkcode Task} is declared
  * as part of a group task, modifiers like `drop: true` or `restartable: true`
@@ -808,15 +977,86 @@ export function task<T extends EncapsulatedTaskDescriptor<any, any[]>>(taskFn: T
  *
  * @function
  * @param {object?} [options={}]
- * @return {TaskGroupProperty}
+ * @return {TaskGroup}
  */
 export function taskGroup<T extends TaskGroupOptions>(baseOptions: T):
-  MethodDecorator & PropertyDecorator;
+  PropertyDecorator;
 export function taskGroup<T>(
   target: Object,
-  propertyKey: string,
-  descriptor?: TypedPropertyDescriptor<T>
-): TypedPropertyDescriptor<T> | void;
+  propertyKey: string
+): void;
+
+/**
+ * Turns the decorated property into a task group and applies the
+ * `drop` modifier.
+ *
+ * Optionally takes a hash of further options that will be applied as modifiers
+ * to the task group.
+ *
+ * @function
+ * @param {object?} [options={}]
+ * @return {TaskGroup}
+ */
+export function dropTaskGroup<T extends TaskGroupOptions>(baseOptions: T):
+  PropertyDecorator;
+export function dropTaskGroup(
+  target: Object,
+  propertyKey: string
+): void;
+
+/**
+ * Turns the decorated property into a task group and applies the
+ * `enqueue` modifier.
+ *
+ * Optionally takes a hash of further options that will be applied as modifiers
+ * to the task group.
+ *
+ * @function
+ * @param {object?} [options={}]
+ * @return {TaskGroup}
+ */
+export function enqueueTaskGroup<T extends TaskGroupOptions>(baseOptions: T):
+  PropertyDecorator;
+export function enqueueTaskGroup<T>(
+  target: Object,
+  propertyKey: string
+): void;
+
+/**
+ * Turns the decorated property into a task group and applies the
+ * `keepLatest` modifier.
+ *
+ * Optionally takes a hash of further options that will be applied as modifiers
+ * to the task group.
+ *
+ * @function
+ * @param {object?} [options={}]
+ * @return {TaskGroup}
+ */
+export function keepLatestTaskGroup<T extends TaskGroupOptions>(baseOptions: T):
+  PropertyDecorator;
+export function keepLatestGroup<T>(
+  target: Object,
+  propertyKey: string
+): void;
+
+/**
+ * Turns the decorated property into a task group and applies the
+ * `restartable` modifier.
+ *
+ * Optionally takes a hash of further options that will be applied as modifiers
+ * to the task group.
+ *
+ * @function
+ * @param {object?} [options={}]
+ * @return {TaskGroup}
+ */
+export function restartableTaskGroup<T extends TaskGroupOptions>(baseOptions: T):
+  PropertyDecorator;
+export function restartableTaskGroup<T>(
+  target: Object,
+  propertyKey: string
+): void;
 
 /**
  * "Task Groups" provide a means for applying

--- a/addon/index.js
+++ b/addon/index.js
@@ -26,35 +26,43 @@ import {
 } from './-private/external/yieldables';
 import { Task } from './-private/task';
 import { TaskGroup } from './-private/task-group';
-
-// Re-export e-c-d, until we merge it.
-export {
-  restartableTask,
+import {
   dropTask,
-  keepLatestTask,
-  enqueueTask,
-  restartableTaskGroup,
   dropTaskGroup,
+  enqueueTask,
+  enqueueTaskGroup,
+  lastValue,
+  keepLatestTask,
   keepLatestTaskGroup,
-  enqueueTaskGroup
-} from 'ember-concurrency-decorators';
+  restartableTask,
+  restartableTaskGroup
+} from './-private/task-decorators';
 
 export {
-  task,
-  taskGroup,
   all,
   allSettled,
   animationFrame,
   didCancel,
+  dropTask,
+  dropTaskGroup,
+  enqueueTask,
+  enqueueTaskGroup,
+  forever,
   hash,
   hashSettled,
+  keepLatestTask,
+  keepLatestTaskGroup,
+  lastValue,
   race,
-  timeout,
   rawTimeout,
+  restartableTask,
+  restartableTaskGroup,
+  task,
+  taskGroup,
+  timeout,
   waitForQueue,
   waitForEvent,
   waitForProperty,
-  forever,
   Task,
   TaskProperty,
   TaskInstance,

--- a/addon/index.js
+++ b/addon/index.js
@@ -4,7 +4,7 @@ import {
   TaskGroupProperty,
   task,
   taskGroup
-} from './-private/computed-properties';
+} from './-private/task-properties';
 import { default as TaskInstance } from './-private/task-instance';
 import {
   all,
@@ -26,6 +26,18 @@ import {
 } from './-private/external/yieldables';
 import { Task } from './-private/task';
 import { TaskGroup } from './-private/task-group';
+
+// Re-export e-c-d, until we merge it.
+export {
+  restartableTask,
+  dropTask,
+  keepLatestTask,
+  enqueueTask,
+  restartableTaskGroup,
+  dropTaskGroup,
+  keepLatestTaskGroup,
+  enqueueTaskGroup
+} from 'ember-concurrency-decorators';
 
 export {
   task,

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,1 @@
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ember-cli-terser": "^4.0.0",
     "ember-code-snippet": "^2.4.0",
     "ember-concurrency-async": "^0.2.1",
+    "ember-concurrency-decorators": "^2.0.0",
     "ember-concurrency-ts": "^0.1.1",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-disable-proxy-controllers": "^1.0.1",
@@ -93,7 +94,6 @@
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-compatibility-helpers": "^1.2.0",
-    "ember-concurrency-decorators": "^2.0.0",
     "ember-destroyable-polyfill": "^2.0.2"
   },
   "ember": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "ember-cli-terser": "^4.0.0",
     "ember-code-snippet": "^2.4.0",
     "ember-concurrency-async": "^0.2.1",
-    "ember-concurrency-decorators": "^2.0.0",
     "ember-concurrency-ts": "^0.1.1",
     "ember-disable-prototype-extensions": "^1.1.3",
     "ember-disable-proxy-controllers": "^1.0.1",
@@ -94,6 +93,7 @@
     "ember-cli-babel": "^7.22.1",
     "ember-cli-htmlbars": "^5.3.1",
     "ember-compatibility-helpers": "^1.2.0",
+    "ember-concurrency-decorators": "^2.0.0",
     "ember-destroyable-polyfill": "^2.0.2"
   },
   "ember": {

--- a/tests/dummy/app/components/task-function-syntax-5/component.js
+++ b/tests/dummy/app/components/task-function-syntax-5/component.js
@@ -16,7 +16,7 @@ export default class MyOctaneComponent extends Component {
     return [];
   }
 
-  @(task(function * () {
+  @task *pickRandomNumbers() {
     let nums = [];
     for (let i = 0; i < 3; i++) {
       nums.push(Math.floor(Math.random() * 10));
@@ -25,6 +25,6 @@ export default class MyOctaneComponent extends Component {
     this.status = `My favorite numbers: ${nums.join(', ')}`;
 
     return nums;
-  })) pickRandomNumbers;
+  }
 }
 // END-SNIPPET

--- a/tests/helpers/helpers.js
+++ b/tests/helpers/helpers.js
@@ -1,4 +1,8 @@
+import { skip, test } from "qunit";
+import { gte } from "ember-compatibility-helpers";
 import Ember from 'ember';
+
+export const decoratorTest = gte('3.10.0') ? test : skip;
 
 export function makeAsyncError(hooks) {
   hooks.afterEach(() => Ember.onerror = null);

--- a/tests/integration/tracked-use-test.js
+++ b/tests/integration/tracked-use-test.js
@@ -4,7 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { later } from '@ember/runloop';
 import { render } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
-import { task, taskGroup, timeout } from 'ember-concurrency';
+import { restartableTask, task, taskGroup, timeout } from 'ember-concurrency';
 import { gte } from 'ember-compatibility-helpers';
 
 module('Integration | tracked use', function(hooks) {
@@ -33,10 +33,10 @@ module('Integration | tracked use', function(hooks) {
             return null;
           }
 
-          @(task(function*() {
+          @restartableTask *exampleTask() {
             yield timeout(1000);
             return 'done';
-          }).restartable()) exampleTask;
+          }
         }
       );
 
@@ -75,12 +75,13 @@ module('Integration | tracked use', function(hooks) {
             return null;
           }
 
-          @(taskGroup().restartable()) exampleGroup;
+          @taskGroup({ restartable: true }) exampleGroup;
 
-          @(task(function*() {
+          @task({ group: 'exampleGroup' })
+          *exampleTask() {
             yield timeout(1000);
             return 'done';
-          }).group('exampleGroup')) exampleTask;
+          }
         }
       );
 

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -31,6 +31,7 @@ import {
   hashSettled,
   race,
   rawTimeout,
+  restartableTask,
   task,
   taskGroup,
   timeout,
@@ -38,7 +39,6 @@ import {
   waitForProperty,
   waitForQueue
 } from 'ember-concurrency';
-import { restartableTask } from 'ember-concurrency-decorators';
 import { taskFor } from 'ember-concurrency-ts';
 import { expectTypeOf as expect } from 'expect-type';
 
@@ -2378,6 +2378,20 @@ module('integration tests', () => {
   test('octane', () => {
     class MyComponent extends GlimmerComponent {
       declare foo: string;
+
+      @task({ restartable: true }) restartable = function*() {};
+      @task({ enqueue: true }) enqueue = function*() {};
+      @task({ drop: true }) drop = function*() {};
+      @task({ keepLatest: true }) keepLatest = function*() {};
+      @task({ evented: true }) evented = function*() {};
+      @task({ debug: true }) debug = function*() {};
+
+      // Note: these options work even when strictFunctionTypes is enabled, but
+      // turning it on in this repo breaks other things in addon/index.d.ts
+      @task({ on: 'hi' }) on = function*() {};
+      @task({ cancelOn: 'bye' }) cancelOn = function*() {};
+      @task({ maxConcurrency: 1 }) maxConcurrency = function*() {};
+      @task({ group: 'foo' }) group = function*() {};
 
       @restartableTask *myTask(immediately: boolean, ms: number = 500): TaskGenerator<string> {
         // We want to assert `this` is not implicitly `any`, but due `this`

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -2377,7 +2377,8 @@ module('integration tests', () => {
 
   test('octane', () => {
     class MyComponent extends GlimmerComponent {
-      declare foo: string;
+      @taskGroup
+      foo!: TaskGroup<any>;
 
       @task({ restartable: true }) restartable = function*() {};
       @task({ enqueue: true }) enqueue = function*() {};
@@ -2409,7 +2410,7 @@ module('integration tests', () => {
 
         // this is probably what we ultimately cares about
         expect(this.foo).not.toBeAny();
-        expect(this.foo).toBeString();
+        expect(this.foo).toEqualTypeOf<TaskGroup<any>>();
 
         if (!immediately) {
           yield timeout(ms);

--- a/tests/unit/decorators-test.js
+++ b/tests/unit/decorators-test.js
@@ -1,0 +1,89 @@
+import { module } from "qunit";
+import { run } from "@ember/runloop";
+import { setOwner } from "@ember/application";
+import {
+  task,
+  restartableTask,
+  dropTask,
+  keepLatestTask,
+  enqueueTask,
+} from "ember-concurrency";
+import { decoratorTest } from '../helpers/helpers';
+
+module("Unit | decorators", function () {
+  decoratorTest("Basic decorators functionality", function (assert) {
+    assert.expect(5);
+
+    class TestSubject {
+      @task doStuff = function* () {
+        yield;
+        return 123;
+      };
+
+      @restartableTask
+      a = function* () {
+        yield;
+        return 456;
+      };
+
+      @keepLatestTask
+      b = function* () {
+        yield;
+        return 789;
+      };
+
+      @dropTask
+      c = function* () {
+        yield;
+        return 12;
+      };
+
+      @enqueueTask
+      d = function* () {
+        yield;
+        return 34;
+      };
+    }
+
+    let subject;
+    run(() => {
+      subject = new TestSubject();
+
+      setOwner(subject, this.owner);
+
+      subject.doStuff.perform();
+      subject.a.perform();
+      subject.b.perform();
+      subject.c.perform();
+      subject.d.perform();
+    });
+
+    assert.equal(subject.doStuff.last.value, 123);
+    assert.equal(subject.a.last.value, 456);
+    assert.equal(subject.b.last.value, 789);
+    assert.equal(subject.c.last.value, 12);
+    assert.equal(subject.d.last.value, 34);
+  });
+
+  decoratorTest("Encapsulated tasks", function (assert) {
+    assert.expect(1);
+
+    class TestSubject {
+      @task encapsulated = {
+        privateState: 56,
+        *perform() {
+          yield;
+          return this.privateState;
+        },
+      };
+    }
+
+    let subject;
+    run(() => {
+      subject = new TestSubject();
+      setOwner(subject, this.owner);
+      subject.encapsulated.perform();
+    });
+    assert.equal(subject.encapsulated.last.value, 56);
+  });
+});

--- a/tests/unit/derived-state/on-state-test.js
+++ b/tests/unit/derived-state/on-state-test.js
@@ -94,7 +94,7 @@ module('Unit: task states - onState', function() {
 
     let fn = function * () { yield forever };
     let changes = [];
-    let onState = (_, task) => changes.push(task._propertyName);
+    let onState = (_, task) => changes.push(task.name);
 
     let Obj = EmberObject.extend({
       a: task(fn).group('gg1').onState(onState),

--- a/tests/unit/encapsulated-task-test.js
+++ b/tests/unit/encapsulated-task-test.js
@@ -2,8 +2,8 @@ import { run } from '@ember/runloop';
 import RSVP from 'rsvp';
 import EmberObject from '@ember/object';
 import { task } from 'ember-concurrency';
-import { gte } from 'ember-compatibility-helpers';
 import { module, test } from 'qunit';
+import { decoratorTest } from '../helpers/helpers';
 
 module('Unit: EncapsulatedTask', function() {
   test("tasks can be specified via a pojos with perform methods", function(assert) {
@@ -56,31 +56,29 @@ module('Unit: EncapsulatedTask', function() {
     assert.equal(taskInstance.someProp, true);
   });
 
-  if (gte('3.10.0')) {
-    test("encapsulated tasks work with native ES classes and decorators", function(assert) {
-      assert.expect(2);
+  decoratorTest("encapsulated tasks work with native ES classes and decorators", function(assert) {
+    assert.expect(2);
 
-      let defer;
+    let defer;
 
-      class FakeGlimmerComponent {
-        @(task({
-          *perform(...args) {
-            assert.deepEqual(args, [1,2,3]);
-            defer = RSVP.defer();
-            yield defer.promise;
-            return 123;
-          }
-        })) myTask;
-      }
+    class FakeGlimmerComponent {
+      @task myTask = {
+        *perform(...args) {
+          assert.deepEqual(args, [1,2,3]);
+          defer = RSVP.defer();
+          yield defer.promise;
+          return 123;
+        }
+      };
+    }
 
-      let obj;
-      run(() => {
-        obj = new FakeGlimmerComponent();
-        obj.myTask.perform(1,2,3).then(v => {
-          assert.equal(v, 123);
-        });
+    let obj;
+    run(() => {
+      obj = new FakeGlimmerComponent();
+      obj.myTask.perform(1,2,3).then(v => {
+        assert.equal(v, 123);
       });
-      run(defer, 'resolve');
     });
-  }
+    run(defer, 'resolve');
+  });
 });

--- a/tests/unit/generator-method-test.js
+++ b/tests/unit/generator-method-test.js
@@ -1,0 +1,63 @@
+import { module } from 'qunit';
+import { run } from '@ember/runloop';
+import {
+  task,
+  restartableTask,
+  dropTask,
+  keepLatestTask,
+  enqueueTask
+} from 'ember-concurrency';
+import { decoratorTest } from '../helpers/helpers';
+
+module('Unit | generator method', function() {
+  decoratorTest('Basic decorators functionality', function(assert) {
+    assert.expect(5);
+
+    class TestSubject {
+      @task
+      *doStuff() {
+        yield;
+        return 123;
+      }
+
+      @restartableTask
+      *a() {
+        yield;
+        return 456;
+      }
+
+      @keepLatestTask
+      *b() {
+        yield;
+        return 789;
+      }
+
+      @dropTask
+      *c() {
+        yield;
+        return 12;
+      }
+
+      @enqueueTask
+      *d() {
+        yield;
+        return 34;
+      }
+    }
+
+    let subject;
+    run(() => {
+      subject = new TestSubject();
+      subject.doStuff.perform();
+      subject.a.perform();
+      subject.b.perform();
+      subject.c.perform();
+      subject.d.perform();
+    });
+    assert.equal(subject.doStuff.last.value, 123);
+    assert.equal(subject.a.last.value, 456);
+    assert.equal(subject.b.last.value, 789);
+    assert.equal(subject.c.last.value, 12);
+    assert.equal(subject.d.last.value, 34);
+  });
+});

--- a/tests/unit/last-value-test.js
+++ b/tests/unit/last-value-test.js
@@ -1,0 +1,57 @@
+import { module } from 'qunit';
+import EmberObject from '@ember/object';
+import { task, lastValue } from 'ember-concurrency';
+import { decoratorTest } from '../helpers/helpers';
+
+module('Unit | lastValue', function() {
+  decoratorTest('without a default value', async function(assert) {
+    class ObjectWithTask extends EmberObject {
+      @task task = function*() {
+        return yield 'foo';
+      };
+
+      @lastValue('task') value;
+    }
+
+    const instance = ObjectWithTask.create();
+    assert.strictEqual(
+      instance.get('value'),
+      undefined,
+      'it returns nothing if the task has not been performed'
+    );
+
+    await instance.get('task').perform();
+
+    assert.strictEqual(
+      instance.get('value'),
+      'foo',
+      'returning the last successful value'
+    );
+  });
+
+  decoratorTest('with a default value', async function(assert) {
+    class ObjectWithTaskDefaultValue extends EmberObject {
+      @task task = function*() {
+        return yield 'foo';
+      };
+
+      @lastValue('task') value = 'default value';
+    }
+
+    const instance = ObjectWithTaskDefaultValue.create();
+
+    assert.strictEqual(
+      instance.get('value'),
+      'default value',
+      'it returns the default value if the task has not been performed'
+    );
+
+    await instance.get('task').perform();
+
+    assert.equal(
+      instance.get('value'),
+      'foo',
+      'returning the last successful value'
+    );
+  });
+});

--- a/tests/unit/task-groups-test.js
+++ b/tests/unit/task-groups-test.js
@@ -2,8 +2,8 @@ import { run } from '@ember/runloop';
 import RSVP from 'rsvp';
 import EmberObject from '@ember/object';
 import { task, taskGroup, forever } from 'ember-concurrency';
-import { gte } from 'ember-compatibility-helpers';
 import { module, test } from 'qunit';
+import { decoratorTest } from '../helpers/helpers';
 
 module('Unit: task groups', function() {
   function assertStates(assert, task, isRunning, isQueued, isIdle, suffix) {
@@ -211,40 +211,38 @@ module('Unit: task groups', function() {
     assertRunning();
   });
 
-  if (gte('3.10.0')) {
-    test("ES class syntax with decorators works with task groups", function(assert) {
-      assert.expect(12);
+  decoratorTest("ES class syntax with decorators works with task groups", function(assert) {
+    assert.expect(12);
 
-      let deferA, deferB;
-      class FakeGlimmerComponent {
-        @(taskGroup().enqueue()) tg;
+    let deferA, deferB;
+    class FakeGlimmerComponent {
+      @taskGroup({ enqueue: true }) tg;
 
-        @(task(function * () {
-          deferA = RSVP.defer();
-          yield deferA.promise;
-        }).group('tg')) taskA;
-
-        @(task(function * () {
-          deferB = RSVP.defer();
-          yield deferB.promise;
-        }).group('tg')) taskB;
+      @task({ group: 'tg' }) *taskA() {
+        deferA = RSVP.defer();
+        yield deferA.promise;
       }
 
-      let obj, taskA, taskB, suffix, tg;
+      @task({ group: 'tg' }) *taskB() {
+        deferB = RSVP.defer();
+        yield deferB.promise;
+      }
+    }
 
-      run(() => {
-        obj = new FakeGlimmerComponent();
-        tg = obj.tg;
-        taskA = obj.taskA;
-        taskB = obj.taskB;
+    let obj, taskA, taskB, suffix, tg;
 
-        taskA.perform();
-      });
+    run(() => {
+      obj = new FakeGlimmerComponent();
+      tg = obj.tg;
+      taskA = obj.taskA;
+      taskB = obj.taskB;
 
-      suffix = "performing taskA";
-      assertStates(assert, tg,    true, false, false, suffix);
-      assertStates(assert, taskA, true, false, false, suffix);
-      assertStates(assert, taskB, false, false, true, suffix);
+      taskA.perform();
     });
-  }
+
+    suffix = "performing taskA";
+    assertStates(assert, tg,    true, false, false, suffix);
+    assertStates(assert, taskA, true, false, false, suffix);
+    assertStates(assert, taskB, false, false, true, suffix);
+  });
 });

--- a/tests/unit/task-groups-test.js
+++ b/tests/unit/task-groups-test.js
@@ -7,10 +7,10 @@ import { decoratorTest } from '../helpers/helpers';
 
 module('Unit: task groups', function() {
   function assertStates(assert, task, isRunning, isQueued, isIdle, suffix) {
-    assert.equal(task.isRunning, isRunning, `${task._propertyName} is ${isRunning ? '' : 'not'} running ${suffix}`);
-    assert.equal(task.isQueued,  isQueued,  `${task._propertyName} is ${isQueued ? '' : 'not'} queued ${suffix}`);
-    assert.equal(task.isIdle,    isIdle,    `${task._propertyName} is ${isIdle ? '' : 'not'} idle ${suffix}`);
-    assert.equal(task.state, isRunning ? 'running' : 'idle', `${task._propertyName} state is '${isRunning ? 'running' : 'idle'}' ${suffix}`)
+    assert.equal(task.isRunning, isRunning, `${task.name} is ${isRunning ? '' : 'not'} running ${suffix}`);
+    assert.equal(task.isQueued,  isQueued,  `${task.name} is ${isQueued ? '' : 'not'} queued ${suffix}`);
+    assert.equal(task.isIdle,    isIdle,    `${task.name} is ${isIdle ? '' : 'not'} idle ${suffix}`);
+    assert.equal(task.state, isRunning ? 'running' : 'idle', `${task.name} state is '${isRunning ? 'running' : 'idle'}' ${suffix}`)
   }
 
   test("task groups allow tasks to share concurrency constraints", function(assert) {

--- a/tests/unit/wait-for-test.js
+++ b/tests/unit/wait-for-test.js
@@ -432,13 +432,13 @@ module('Unit: test waitForQueue and waitForEvent and waitForProperty', function(
         return this.a;
       }
 
-      @(task(function*() {
+      @task *task() {
         let result = yield waitForProperty(this, 'b', v => {
           values.push(v);
           return v == 3 ? 'done' : false;
         });
         values.push(`val=${result}`);
-      })) task;
+      }
     }
 
     let obj = new Obj();

--- a/tests/unit/wait-for-test.js
+++ b/tests/unit/wait-for-test.js
@@ -11,7 +11,7 @@ import {
   race
 } from 'ember-concurrency';
 import { alias } from '@ember/object/computed';
-import { gte } from 'ember-compatibility-helpers';
+import { decoratorTest } from '../helpers/helpers';
 
 const EventedObject = EmberObject.extend(Evented);
 
@@ -420,41 +420,39 @@ module('Unit: test waitForQueue and waitForEvent and waitForProperty', function(
     assert.equal(ev, 456);
   });
 
-  if (gte('3.10.0')) {
-    test('waitForProperty works on an ES class', async function(assert) {
-      assert.expect(1);
+  decoratorTest('waitForProperty works on an ES class', async function(assert) {
+    assert.expect(1);
 
-      let values = [];
-      class Obj {
-        a = 1;
+    let values = [];
+    class Obj {
+      a = 1;
 
-        @computed('a')
-        get b() {
-          return this.a;
-        }
-
-        @(task(function*() {
-          let result = yield waitForProperty(this, 'b', v => {
-            values.push(v);
-            return v == 3 ? 'done' : false;
-          });
-          values.push(`val=${result}`);
-        })) task;
+      @computed('a')
+      get b() {
+        return this.a;
       }
 
-      let obj = new Obj();
-      obj.task.perform();
+      @(task(function*() {
+        let result = yield waitForProperty(this, 'b', v => {
+          values.push(v);
+          return v == 3 ? 'done' : false;
+        });
+        values.push(`val=${result}`);
+      })) task;
+    }
 
-      set(obj, 'a', 2);
-      await settled();
+    let obj = new Obj();
+    obj.task.perform();
 
-      set(obj, 'a', 3);
-      await settled();
+    set(obj, 'a', 2);
+    await settled();
 
-      set(obj, 'a', 4);
-      await settled();
+    set(obj, 'a', 3);
+    await settled();
 
-      assert.deepEqual(values, [1, 2, 3, 'val=3']);
-    });
-  }
+    set(obj, 'a', 4);
+    await settled();
+
+    assert.deepEqual(values, [1, 2, 3, 'val=3']);
+  });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "es6",
     "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "target": "es6",
     "experimentalDecorators": true,
-    "emitDecoratorMetadata": true,
     "moduleResolution": "node",
     "noEmit": true,
     "strict": true,


### PR DESCRIPTION
Supersedes #384 

This provides built-in support for the "nice" decorator syntax based on the decorators implemented at [`ember-concurrency-decorators`](https://github.com/machty/ember-concurrency-decorators). Many thanks to @buschtoens for years of stewardship of that addon, and important contributions from @chancancode for TypeScript support, and others in the community to get it to a place where it's seen wide adoption in the world of Ember Octane, TypeScript, and native ES classes.

The "ugly" decorators (e.g. (`@(task(function* () { ... }).drop()`) will remain available by virtue of coming "for free" with the computed-based `TaskProperty` implementation (necessary to support the classic EmberObject model for task hosts), but will be deprecated in favor of these "nice" decorators at some point in the future.

A follow-up PR will convert all the docs to also using these "nice" decorators.