### PR TITLE
v2: Add decorator docs from ember-concurrency-decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,6 @@ found [here](http://ember-concurrency.com).
 
     ember install ember-concurrency
 
-If you're using a version of `ember-concurrency` older than 0.7.5,
-you'll also need to run:
-
-    ember install ember-maybe-import-regenerator
-
 ## Documentation
 
 The [ember-concurrency documentation site](http://ember-concurrency.com) is an ember-cli app
@@ -42,11 +37,11 @@ approach).
 
 See the [Contributing](CONTRIBUTING.md) guide for details.
 
-[build-status-img]: https://travis-ci.org/machty/ember-concurrency.svg?branch=master
-[build-status-link]: https://travis-ci.org/machty/ember-concurrency
+[build-status-img]: https://travis-ci.com/machty/ember-concurrency.svg?branch=master
+[build-status-link]: https://travis-ci.com/machty/ember-concurrency
 [npm-badge-img]: https://badge.fury.io/js/ember-concurrency.svg
 [npm-badge-link]: http://badge.fury.io/js/ember-concurrency
 [ember-observer-badge]: http://emberobserver.com/badges/ember-concurrency.svg
 [ember-observer-url]: http://emberobserver.com/addons/ember-concurrency
-[ember-version]: https://img.shields.io/badge/Ember-2.4%2B-brightgreen.svg
+[ember-version]: https://img.shields.io/badge/Ember-3.8+-brightgreen.svg
 [twiddle-starter]: https://ember-twiddle.com/b2b0c016f4df24261381487b60c707f3?numColumns=2&openFiles=templates.application.hbs%2Ctemplates.application.hbs

--- a/UPGRADING-2.x.md
+++ b/UPGRADING-2.x.md
@@ -10,6 +10,32 @@ semantic changes to the operation of the addon.
 
 ## Changes
 
+### Decorators from `ember-concurrency-decorators` are built-in
+
+This provides built-in support for the "nice" decorator syntax based on the
+decorators implemented at ember-concurrency-decorators. Many thanks to
+@buschtoens for years of stewardship of that addon, and important contributions
+from @chancancode for TypeScript support, and others in the community to get it
+to a place where it's seen wide adoption in the world of Ember Octane,
+TypeScript, and native ES classes.
+
+The "ugly" decorators (e.g. (@(task(function* () { ... }).drop()) will remain
+available by virtue of coming "for free" with the computed-based TaskProperty
+implementation (necessary to support the classic EmberObject model for task
+hosts), but are deprecated to be removed in favor of these "nice" decorators
+at some point in the future.
+
+To migrate, simply replace `ember-concurrency-decorators` imports with `ember-concurrency`.
+
+```diff
+- import { restartableTask, task } from 'ember-concurrency-decorators';
++ import { restartableTask, task } from 'ember-concurrency';
+```
+
+Use of the computed property-based `task(function* () {})` for Ember Classic
+objects remains available and unchanged, however the docs will now use native
+classes and decorators for most examples.
+
 ### Task, TaskGroup, and TaskInstance no longer extend `EmberObject`
 
 This mostly impacts the TypeScript type definitions, and use with older styles of
@@ -113,7 +139,9 @@ Modern evergreen browsers are supported, with Firefox and Chrome being tested in
 CI. Other browsers, such as Safari, Edge, and IE 11 should work fine as well,
 though the latter may require transpilation or polyfills via your
 `config/targets.js` or babel configuration. In particular, native ES classes,
-`WeakMap`, and `Proxy` are used.
+`WeakMap`, and `Proxy` are used. However, `Proxy` may not be polyfillable, but is
+only required for encapsulated tasks. If you do not use this feature, you can
+likely still use ember-concurrency with older browsers.
 
 ### Notes to addon maintainers
 
@@ -126,6 +154,11 @@ might take some time to upgrade to support the latest.
 ember-concurrency 1.x and 2.x are more-or-less the same API, while being _very_
 different internally.
 
+If you use decorators via `ember-concurrency-decorators` and wish to support
+both ember-concurrency 1.x and 2.x, you must keep using
+`ember-concurrency-decorators` and not use the "nice" decorators built-in to
+`ember-concurrency` 2.x, as they will not work under 1.x
+
 #### package.json
 
 Please accept versions liberally if you can, or use an appropriate version
@@ -136,7 +169,7 @@ specifier for your requirements:
     // ...
     "dependencies": { // Or use `peerDependencies` if appropriate
       // ...
-      "ember-concurrency": ">=1.0.0 <3", // or "^1.0.0 || ^2.0.0-beta.1"
+      "ember-concurrency": "^1.0.0 || ^2.0.0-beta.1",
       // ...
     },
     // ...

--- a/tests/dummy/app/application/controller.js
+++ b/tests/dummy/app/application/controller.js
@@ -1,7 +1,7 @@
 import Controller from '@ember/controller';
 import config from '../config/environment';
 
-const versionRegExp = /\d+[.]\d+[.]\d+/;
+const versionRegExp = /\d+[.]\d+[.]\d+(?:-(?:alpha|beta|rc)\.\d+)?/;
 const {
   APP: { version }
 } = config;

--- a/tests/dummy/app/docs/controller.js
+++ b/tests/dummy/app/docs/controller.js
@@ -12,7 +12,12 @@ export const TABLE_OF_CONTENTS = [
   { route: "docs.tutorial.refactor", title: "Refactoring With Tasks" },
 
   { section: "Reference" },
-  { route: "docs.task-function-syntax", title: "Task Function Syntax" },
+  { route: "docs.task-function-syntax", title: "Task Function Syntax",
+    children: [
+      { route: "docs.task-decorators", title: "Decorators" },
+      { route: "docs.typescript", title: "TypeScript" },
+    ]
+  },
   { route: "docs.task-concurrency", title: "Managing Task Concurrency",
     children: [
       { route: "docs.task-concurrency-advanced", title: "Advanced" },
@@ -27,7 +32,6 @@ export const TABLE_OF_CONTENTS = [
   { route: "docs.events", title: "Awaiting Events / Conditions" },
   { route: "docs.task-lifecycle-events", title: "Lifecycle Events" },
   { route: "docs.testing-debugging", title: "Testing & Debugging" },
-  { route: "docs.typescript", title: "TypeScript" },
   { route: "docs.faq", title: "FAQ & Fact Sheet" },
 
   { section: "Examples" },

--- a/tests/dummy/app/docs/installation/template.hbs
+++ b/tests/dummy/app/docs/installation/template.hbs
@@ -7,8 +7,9 @@
 <CodeSnippet @name="ember-install.sh" />
 
 <p>
-  To use with native JavaScript/TypeScript classes and decorator syntax (<strong>Recommended</strong>)
-  as used throughout this documentation, ensure you also meet the following in your application:
+  (<strong>Recommended</strong>) To use with native JavaScript/TypeScript classes
+  and decorator syntax as used throughout this documentation, ensure you also
+  meet the following in your application/addon:
 
   <ul>
     <li>At least <code>ember-cli-babel@^7.7.2</code></li>

--- a/tests/dummy/app/docs/installation/template.hbs
+++ b/tests/dummy/app/docs/installation/template.hbs
@@ -5,3 +5,16 @@
 </p>
 
 <CodeSnippet @name="ember-install.sh" />
+
+<p>
+  To use with native JavaScript/TypeScript classes and decorator syntax (<strong>Recommended</strong>)
+  as used throughout this documentation, ensure you also meet the following in your application:
+
+  <ul>
+    <li>At least <code>ember-cli-babel@^7.7.2</code></li>
+    <li>At least <code>@babel/core@^7.5.0</code> (as a transitive dependency via <code>ember-cli-babel</code>)</li>
+    <li>At least <code>ember-cli-typescript@^2.0.0</code> and TypeScript 3.7+, if you want to use it with TypeScript</li>
+    <li><code>@ember-decorators/babel-transforms</code> is _not_ installed</li>
+    <li>Below Ember v3.10: <a href="https://github.com/pzuraq/ember-decorators-polyfill" rel="noreferrer noopener"><code>ember-decorators-polyfill</code></a> is needed</li>
+  </ul>
+</p>

--- a/tests/dummy/app/docs/task-decorators/template.hbs
+++ b/tests/dummy/app/docs/task-decorators/template.hbs
@@ -1,0 +1,189 @@
+<h2>Using Task Decorators</h2>
+
+<p>
+  Since 2.0.0, ember-concurrency uses the <a href="https://github.com/tc39/proposal-decorators" rel="noreferrer noopener">Stage 1 proposed decorator syntax</a>
+  for declaring/configuring ember-concurrency tasks on native
+  JavaScript/TypeScript classes. This syntax was previously provided by the
+  <a href="https://github.com/machty/ember-concurrency-decorators">ember-concurrency-decorators</a>
+  addon, but was merged into ember-concurrency. It is still available as a seperate
+  addon for use with ember-concurrency 1.x and earlier, or when supporting both
+  ember-concurrency v1 and v2 in an addon using decorators.
+</p>
+
+<p>
+  For more context on decorators and Ember, you can read an excellent briefing on
+  decorator syntax in modern Ember here:
+  <a href="https://www.pzuraq.com/coming-soon-in-ember-octane-part-1-native-classes/" rel="noreferrer noopener">Coming soon in Ember Octane (Part 1): Native Classes</a>
+</p>
+
+<h3 id="available-decorators">Available decorators</h3>
+
+<ul>
+  <li>
+    <strong><a href="#task"><code>@task</code></a></strong>:
+    turns a generator method into a task
+
+    <ul>
+      <li><code>@restartableTask</code></li>
+      <li><code>@dropTask</code></li>
+      <li><code>@keepLatestTask</code></li>
+      <li><code>@enqueueTask</code></li>
+    </ul>
+  </li>
+
+  <li>
+    <strong><a href="#task-group"><code>@taskGroup</code></a></strong>:
+    creates a task group from a property
+
+    <ul>
+      <li><code>@restartableTaskGroup</code></li>
+      <li><code>@dropTaskGroup</code></li>
+      <li><code>@keepLatestTaskGroup</code></li>
+      <li><code>@enqueueTaskGroup</code></li>
+    </ul>
+  </li>
+
+  <li>
+    <strong><a href="#last-value"><code>@lastValue</code></a></strong>:
+    alias a property to the result of a task with an optional default value
+  </li>
+</ul>
+
+<h4 id="task"><code>@task</code></h4>
+
+<CodeSnippet @name="task-decorators-1.js" />
+
+<p>You can also pass further options to the task decorator:</p>
+
+<CodeSnippet @name="task-decorators-2.js" />
+
+<p>You can also use task lifecycle event hooks in your tasks:</p>
+
+<CodeSnippet @name="task-decorators-3.js" />
+
+<p>
+  For your convenience, there are extra decorators for all
+  <LinkTo @route="docs.task-concurrency">concurrency modifiers</LinkTo>:
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Shorthand</th>
+      <th>Equivalent</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>@restartableTask</code></td>
+      <td><code>@task({ restartable: true })</code></td>
+    </tr>
+    <tr>
+      <td><code>@dropTask</code></td>
+      <td><code>@task({ drop: true })</code></td>
+    </tr>
+    <tr>
+      <td><code>@keepLatestTask</code></td>
+      <td><code>@task({ keepLatest: true })</code></td>
+    </tr>
+    <tr>
+      <td><code>@enqueueTask</code></td>
+      <td><code>@task({ enqueue: true })</code></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>You can still pass further options to these decorators, like:</p>
+
+<CodeSnippet @name="task-decorators-4.js" />
+
+<h5>Encapsulated Tasks</h5>
+
+<blockquote>
+  <LinkTo @route="docs.encapsulated-task">Encapsulated Tasks</LinkTo> behave just
+  like regular tasks, but with one crucial difference: the value of <code>this</code>
+  within the task function points to the currently running TaskInstance, rather
+  than the host object that the task lives on (e.g. a Component, Controller, etc).
+  This allows for some nice patterns where all of the state produced/mutated by a
+  task can be contained (encapsulated) within the Task itself, rather than having
+  to live on the host object.
+</blockquote>
+
+<CodeSnippet @name="task-decorators-5.js" />
+
+<p>
+  Unfortunately, encapsulated tasks have challenges with TypeScript.
+  See the <a href="#typescript-support">TypeScript</a> section for more details.
+</p>
+
+<h4 id="task-group"><code>@taskGroup</code></h4>
+
+<CodeSnippet @name="task-group-decorators-1.js" />
+
+<p>You can also pass further options to the task group decorator:</p>
+
+<CodeSnippet @name="task-group-decorators-2.js" />
+
+<p>
+  As for <code>@task</code>, there are extra decorators for all
+  <LinkTo @route="docs.task-concurrency">concurrency modifiers</LinkTo>:
+</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Shorthand</th>
+      <th>Equivalent</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>@restartableTaskGroup</code></td>
+      <td><code>@taskGroup({ restartable: true })</code></td>
+    </tr>
+    <tr>
+      <td><code>@dropTaskGroup</code></td>
+      <td><code>@taskGroup({ drop: true })</code></td>
+    </tr>
+    <tr>
+      <td><code>@keepLatestTaskGroup</code></td>
+      <td><code>@taskGroup({ keepLatest: true })</code></td>
+    </tr>
+    <tr>
+      <td><code>@enqueueTaskGroup</code></td>
+      <td><code>@taskGroup({ enqueue: true })</code></td>
+    </tr>
+  </tbody>
+</table>
+
+<p>You can still pass further options to these decorators, like:</p>
+
+<CodeSnippet @name="task-group-decorators-3.js" />
+
+<h4 id="last-value"><code>@lastValue</code></h4>
+
+<p>
+  This decorator allows you to alias a property to the result of a task.
+  You can also provide a default value to use before the task has completed.
+</p>
+
+<CodeSnippet @name="last-value-decorator.js" />
+
+<h2 id="typescript-support">TypeScript Support</h2>
+
+<p>
+  You can use this package with TypeScript, <em>but</em> unfortunately decorators
+  cannot yet change the type signature of the decorated element. This is why you
+  may get type errors like:
+</p>
+
+<CodeSnippet @name="ts/broken.ts" />
+
+<pre>
+TS2339: Property 'perform' does not exist on type '() => IterableIterator&lt;any&gt;'.
+</pre>
+
+<p>
+  See the <LinkTo @route="docs.typescript">documentation on TypeScript</LinkTo>
+  for details and workarounds.
+</p>

--- a/tests/dummy/app/docs/task-decorators/template.hbs
+++ b/tests/dummy/app/docs/task-decorators/template.hbs
@@ -180,7 +180,7 @@
 <CodeSnippet @name="ts/broken.ts" />
 
 <pre>
-TS2339: Property 'perform' does not exist on type '() => IterableIterator&lt;any&gt;'.
+error TS2339: Property 'perform' does not exist on type '(this: Foo) => Generator:&lt;never, void, unknown&gt;'.
 </pre>
 
 <p>

--- a/tests/dummy/app/docs/testing-debugging/template.hbs
+++ b/tests/dummy/app/docs/testing-debugging/template.hbs
@@ -124,3 +124,29 @@
   To enable lifecycle logging on ALL ember-concurrency tasks, you can enable the <code>DEBUG_TASKS</code>
   flag on <code>EmberENV</code> in your project's <code>config/environment.js</code> file.
 </p>
+
+<h4>Strange errors when using as documented</h4>
+
+<p>
+  Check the <LinkTo @route="docs.installation">requirements</LinkTo> to see what
+  you need to install.
+</p>
+
+<p>
+  If you are sure that you fulfilled the requirements correctly, but are still
+  experiencing weird errors, install
+  <a href="https://github.com/salsify/ember-cli-dependency-lint" rel="noreferrer noopener"><code>ember-cli-dependency-lint</code></a>
+  to ensure that you are not accidentally including outdated versions of
+  <code>ember-concurrency</code> as a transitive dependency. You may need to file
+  an issue with the relevant dependency to update their ember-concurrency dependency
+  range. Alternatively, you might resort to using something like Yarn resolutions
+  to enforce your application's version of ember-concurrency, but this depends on
+  how its being used by the dependency.
+</p>
+
+<p>
+  If it's still not working after that, please reach out on the
+  <code>#e-concurrency</code> channel on the
+  <a href="https://discord.gg/zT3asNS" rel="noreferrer noopener">Ember Community Discord server</a> or file
+  a <a href="https://github.com/machty/ember-concurrency/issues/new" rel="noreferrer noopener">new issue</a>.
+</p>

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -18,8 +18,10 @@ Router.map(function() {
     });
 
     this.route('task-function-syntax');
+    this.route('task-decorators');
     this.route('task-concurrency');
     this.route('task-concurrency-advanced');
+
     this.route('cancelation');
     this.route('error-vs-cancelation');
     this.route('child-tasks');

--- a/tests/dummy/snippets/last-value-decorator.js
+++ b/tests/dummy/snippets/last-value-decorator.js
@@ -1,0 +1,16 @@
+import Component from '@ember/component';
+import { task } from 'ember-concurrency';
+import { lastValue } from 'ember-concurrency';
+
+export default class ExampleComponent extends Component {
+  @task
+  *someTask() {
+    // ...
+  }
+
+  @lastValue('someTask')
+  someTaskValue;
+
+  @lastValue('someTask')
+  someTaskValueWithDefault = 'A default value';
+}

--- a/tests/dummy/snippets/task-decorators-1.js
+++ b/tests/dummy/snippets/task-decorators-1.js
@@ -1,0 +1,16 @@
+import Component from '@ember/component';
+import { task } from 'ember-concurrency';
+
+export default class ExampleComponent extends Component {
+  @task
+  *doStuff() {
+    // ...
+  }
+
+  // and then elsewhere
+  executeTheTask() {
+    // `doStuff` is still a `Task` object that can be `.perform()`ed
+    this.doStuff.perform();
+    console.log(this.doStuff.isRunning);
+  }
+}

--- a/tests/dummy/snippets/task-decorators-2.js
+++ b/tests/dummy/snippets/task-decorators-2.js
@@ -1,0 +1,7 @@
+@task({
+  maxConcurrency: 3,
+  restartable: true
+})
+*doStuff() {
+  // ...
+}

--- a/tests/dummy/snippets/task-decorators-3.js
+++ b/tests/dummy/snippets/task-decorators-3.js
@@ -1,0 +1,4 @@
+@task({ on: 'didInsertElement' })
+*doStuff() {
+  // ...
+}

--- a/tests/dummy/snippets/task-decorators-4.js
+++ b/tests/dummy/snippets/task-decorators-4.js
@@ -1,0 +1,4 @@
+@restartableTask({ maxConcurrency: 3 })
+*doStuff() {
+  // ...
+}

--- a/tests/dummy/snippets/task-decorators-5.js
+++ b/tests/dummy/snippets/task-decorators-5.js
@@ -1,0 +1,19 @@
+import Component from '@ember/component';
+import { task } from 'ember-concurrency';
+
+export default class ExampleComponent extends Component {
+  @task
+  doStuff = {
+    privateState: 123,
+    *perform() {
+      // ...
+    }
+  };
+
+  // and then elsewhere
+  executeTheTask() {
+    // `doStuff` is still a `Task` object that can be `.perform()`ed
+    this.doStuff.perform();
+    console.log(this.doStuff.isRunning);
+  }
+}

--- a/tests/dummy/snippets/task-group-decorators-1.js
+++ b/tests/dummy/snippets/task-group-decorators-1.js
@@ -1,0 +1,26 @@
+import Component from '@ember/component';
+import { task, taskGroup } from 'ember-concurrency';
+
+export default class ExampleComponent extends Component {
+  @taskGroup
+  someTaskGroup;
+
+  @task({ group: 'someTaskGroup' })
+  *doStuff() {
+    // ...
+  }
+
+  @task({ group: 'someTaskGroup' })
+  *doOtherStuff() {
+    // ...
+  }
+
+  // and then elsewhere
+  executeTheTask() {
+    // `doStuff` is still a `Task `object that can be `.perform()`ed
+    this.doStuff.perform();
+
+    // `someTaskGroup` is still a `TaskGroup` object
+    console.log(this.someTaskGroup.isRunning);
+  }
+}

--- a/tests/dummy/snippets/task-group-decorators-2.js
+++ b/tests/dummy/snippets/task-group-decorators-2.js
@@ -1,0 +1,4 @@
+@taskGroup({
+  maxConcurrency: 3,
+  drop: true
+}) someTaskGroup;

--- a/tests/dummy/snippets/task-group-decorators-3.js
+++ b/tests/dummy/snippets/task-group-decorators-3.js
@@ -1,0 +1,1 @@
+@dropTaskGroup({ maxConcurrency: 3 }) someTaskGroup;

--- a/tests/dummy/snippets/ts/broken.ts
+++ b/tests/dummy/snippets/ts/broken.ts
@@ -1,0 +1,12 @@
+import { task } from 'ember-concurrency';
+
+export default class Foo {
+  @task
+  *doStuff(this: Foo) {
+    // ...
+  }
+
+  executeTheTask() {
+    this.doStuff.perform();
+  }
+}

--- a/tests/dummy/snippets/ts/broken.ts
+++ b/tests/dummy/snippets/ts/broken.ts
@@ -7,6 +7,7 @@ export default class Foo {
   }
 
   executeTheTask() {
+    // @ts-ignore
     this.doStuff.perform();
   }
 }


### PR DESCRIPTION
Last piece of the [ember-concurrency-decorators](https://github.com/machty/ember-concurrency-decorators) merge for v2. It's more or less a copy of the README from that project with some minor tweaks and reorganization of some FAQ stuff