### PR TITLE
v2: Make cancel & cancelAll awaitable

### DIFF
--- a/addon/-private/external/scheduler/scheduler.js
+++ b/addon/-private/external/scheduler/scheduler.js
@@ -23,12 +23,14 @@ class Scheduler {
     this.taskInstances = [];
   }
 
-  cancelAll(guid, cancelRequest) {
-    this.taskInstances.forEach(taskInstance => {
+  async cancelAll(guid, cancelRequest) {
+    let cancelations = this.taskInstances.map(taskInstance => {
       if (taskInstance.task.guids[guid]) {
         taskInstance.executor.cancel(cancelRequest);
       }
-    });
+    }).filter(cancelation => !!cancelation);
+
+    await Promise.all(cancelations);
   }
 
   perform(taskInstance) {

--- a/addon/-private/external/scheduler/scheduler.js
+++ b/addon/-private/external/scheduler/scheduler.js
@@ -23,14 +23,14 @@ class Scheduler {
     this.taskInstances = [];
   }
 
-  async cancelAll(guid, cancelRequest) {
+  cancelAll(guid, cancelRequest) {
     let cancelations = this.taskInstances.map(taskInstance => {
       if (taskInstance.task.guids[guid]) {
         taskInstance.executor.cancel(cancelRequest);
       }
     }).filter(cancelation => !!cancelation);
 
-    await Promise.all(cancelations);
+    return Promise.all(cancelations);
   }
 
   perform(taskInstance) {

--- a/addon/-private/external/task-instance/cancelation.js
+++ b/addon/-private/external/task-instance/cancelation.js
@@ -32,5 +32,8 @@ export class CancelRequest {
   constructor(kind, reason) {
     this.kind = kind;
     this.reason = reason;
+    this.promise = new Promise((resolve) => {
+      this.finalize = resolve;
+    });
   }
 }

--- a/addon/-private/external/task-instance/executor.js
+++ b/addon/-private/external/task-instance/executor.js
@@ -58,7 +58,8 @@ export class TaskInstanceExecutor {
 
   cancel(cancelRequest) {
     if (!this.requestCancel(cancelRequest)) {
-      return;
+      cancelRequest.finalize();
+      return cancelRequest.promise;
     }
 
     if (this.state.hasStarted) {
@@ -66,6 +67,8 @@ export class TaskInstanceExecutor {
     } else {
       this.finalizeWithCancel();
     }
+
+    return this.cancelRequest.promise;
   }
 
   setState(state) {
@@ -399,6 +402,8 @@ export class TaskInstanceExecutor {
       error,
       cancelReason
     });
+
+    this.cancelRequest.finalize();
   }
 
   debugEnabled() {

--- a/addon/-private/external/task/taskable.js
+++ b/addon/-private/external/task/taskable.js
@@ -22,16 +22,16 @@ export class Taskable {
     }
   }
 
-  async cancelAll(options) {
+  cancelAll(options) {
     let { reason, cancelRequestKind, resetState } = options || {};
     reason = reason || ".cancelAll() was explicitly called on the Task";
 
     let cancelRequest = new CancelRequest(cancelRequestKind || CANCEL_KIND_EXPLICIT, reason);
-    await this.scheduler.cancelAll(this.guid, cancelRequest);
-
-    if (resetState) {
-      this._resetState();
-    }
+    return this.scheduler.cancelAll(this.guid, cancelRequest).then(() => {
+      if (resetState) {
+        this._resetState();
+      }
+    });
   }
 
   _resetState() {

--- a/addon/-private/external/task/taskable.js
+++ b/addon/-private/external/task/taskable.js
@@ -22,12 +22,12 @@ export class Taskable {
     }
   }
 
-  cancelAll(options) {
+  async cancelAll(options) {
     let { reason, cancelRequestKind, resetState } = options || {};
     reason = reason || ".cancelAll() was explicitly called on the Task";
 
     let cancelRequest = new CancelRequest(cancelRequestKind || CANCEL_KIND_EXPLICIT, reason);
-    this.scheduler.cancelAll(this.guid, cancelRequest);
+    await this.scheduler.cancelAll(this.guid, cancelRequest);
 
     if (resetState) {
       this._resetState();

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -117,7 +117,7 @@ interface AbstractTask<Args extends any[], T extends TaskInstance<any>> {
    *   (`last*` and `performCount` properties will be set to initial
    *   values). Defaults to false.
    */
-  cancelAll(options?: { reason?: string, resetState?: boolean }): void;
+  cancelAll(options?: { reason?: string, resetState?: boolean }): Promise<void>;
 
   /**
    * Creates a new {@linkcode TaskInstance} and attempts to run it right away.
@@ -263,7 +263,7 @@ export interface TaskGroup<T> {
    *   (`last*` and `performCount` properties will be set to initial
    *   values). Defaults to false.
    */
-  cancelAll(options?: { reason?: string, resetState?: boolean }): void;
+  cancelAll(options?: { reason?: string, resetState?: boolean }): Promise<void>;
 }
 
 /**
@@ -355,7 +355,7 @@ export interface TaskInstance<T> extends Promise<T> {
    *
    * @param cancelReason Defaults to `".cancel() was explicitly called"`.
    */
-  cancel(cancelReason?: string): void;
+  cancel(cancelReason?: string): Promise<void>;
 
   /**
    * Returns a promise that resolves with the value returned

--- a/tests/dummy/app/helpers-test/template.hbs
+++ b/tests/dummy/app/helpers-test/template.hbs
@@ -3,7 +3,7 @@
 <p class="task-status">{{this.status}}</p>
 
 <MyButton @action={{perform this.myTask 1 2}} @class="perform-task">Perform</MyButton>
-<MyButton @action={{cancel-all this.myTask 1 2}} @class="cancel-task">Cancel</MyButton>
+<button {{on "click" (cancel-all this.myTask)}} type="button" class="cancel-task">Cancel</button>
 <MyButton @action={{perform this.returnValue}} @class="value-task">Return a Value</MyButton>
 
 <button {{on "click" (perform this.maybeNullTask)}} class="maybe-null-task" type="button">Maybe Null Task</button>

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -343,7 +343,7 @@ module('unit tests', () => {
     expect(t.cancelAll).toBeCallableWith({ resetState: true });
     expect(t.cancelAll).toBeCallableWith({ reason: 'why do you care', resetState: true });
     expect(t.cancelAll).parameters.toEqualTypeOf<[{ reason?: string, resetState?: boolean }?]>();
-    expect(t.cancelAll).returns.toEqualTypeOf<void>();
+    expect(t.cancelAll).returns.toEqualTypeOf<Promise<void>>();
 
     // @ts-expect-error
     t.cancelAll(null);
@@ -416,7 +416,7 @@ module('unit tests', () => {
     expect(t.cancelAll).toBeCallableWith({ resetState: true });
     expect(t.cancelAll).toBeCallableWith({ reason: 'why do you care', resetState: true });
     expect(t.cancelAll).parameters.toEqualTypeOf<[{ reason?: string, resetState?: boolean }?]>();
-    expect(t.cancelAll).returns.toEqualTypeOf<void>();
+    expect(t.cancelAll).returns.toEqualTypeOf<Promise<void>>();
 
     // @ts-expect-error
     t.cancelAll(null);
@@ -487,7 +487,7 @@ module('unit tests', () => {
     expect(tg.cancelAll).toBeCallableWith({ resetState: true });
     expect(tg.cancelAll).toBeCallableWith({ reason: 'why do you care', resetState: true });
     expect(tg.cancelAll).parameters.toEqualTypeOf<[{ reason?: string, resetState?: boolean }?]>();
-    expect(tg.cancelAll).returns.toEqualTypeOf<void>();
+    expect(tg.cancelAll).returns.toEqualTypeOf<Promise<void>>();
 
     // @ts-expect-error
     tg.cancelAll(null);
@@ -523,7 +523,7 @@ module('unit tests', () => {
     expect(t.cancel).toBeCallableWith();
     expect(t.cancel).toBeCallableWith('why do you care');
     expect(t.cancel).parameters.toEqualTypeOf<[string?]>();
-    expect(t.cancel).returns.toEqualTypeOf<void>();
+    expect(t.cancel).returns.toEqualTypeOf<Promise<void>>();
 
     expect(t).toMatchTypeOf<Promise<string>>();
     expect(t).resolves.toBeString();


### PR DESCRIPTION
Cancelation is async, but cancel and cancelAll have not returned promises to enable awaiting cancelation. This PR changes that so the two can be used with async/await and/or Promises to ensure consuming applications can reliably schedule subsequent operations that may depend on cancelation

For example,

```javascript
@dropTask *myTask() {
  while(1) {
   console.log("hello!");
   yield timeout(1000);
  }
}

@task *restartMyTask() {
  // Note the `yield`. This could also be an `await` or `then` outside of tasks
  yield this.myTask.cancelAll();

  // Without being able to `yield` on `cancelAll` above, the cancelation wouldn't be guaranteed to have taken place before this is called, resulting in `perform` no-oping and dropping the task and myTask would not restart
  this.myTask.perform();
}
```