### PR TITLE
Restore access to host context from encapsulated tasks

### DIFF
--- a/addon/-private/task.js
+++ b/addon/-private/task.js
@@ -284,7 +284,9 @@ export class EncapsulatedTask extends Task {
 
   _taskInstanceFactory(args, performType) {
     let owner = getOwner(this.context);
-    let encapsulatedTaskImpl = EmberObject.extend(this.taskObj).create();
+    let encapsulatedTaskImpl = EmberObject.extend(this.taskObj).create({
+      context: this.context
+    });
     setOwner(encapsulatedTaskImpl, owner);
 
     let generatorFactory = () => encapsulatedTaskImpl.perform.apply(encapsulatedTaskImpl, args);

--- a/tests/unit/encapsulated-task-test.js
+++ b/tests/unit/encapsulated-task-test.js
@@ -6,7 +6,7 @@ import { module, test } from 'qunit';
 import { decoratorTest } from '../helpers/helpers';
 
 module('Unit: EncapsulatedTask', function() {
-  test("tasks can be specified via a pojos with perform methods", function(assert) {
+  test("encapsulated tasks can be specified via a pojos with perform methods", function(assert) {
     assert.expect(2);
 
     let defer;
@@ -31,7 +31,7 @@ module('Unit: EncapsulatedTask', function() {
     run(defer, 'resolve');
   });
 
-  test("tasks can have their state accessed", async function(assert) {
+  test("encapsulated tasks can have their state accessed", async function(assert) {
     assert.expect(2);
 
     let defer;
@@ -54,6 +54,32 @@ module('Unit: EncapsulatedTask', function() {
     defer.resolve();
     await taskInstance;
     assert.equal(taskInstance.someProp, true);
+  });
+
+  test("encapsulated tasks can access host context", async function(assert) {
+    assert.expect(1);
+
+    let defer;
+    let Obj = EmberObject.extend({
+      mySecretValue: "pickle",
+
+      myTask: task({
+        someProp: false,
+
+        *perform() {
+          defer = RSVP.defer();
+          yield defer.promise;
+          return this.context.mySecretValue;
+        }
+      }),
+    });
+
+    let obj = Obj.create();
+    const taskInstance = obj.get('myTask').perform();
+
+    defer.resolve();
+    const value = await taskInstance;
+    assert.equal(value, "pickle");
   });
 
   decoratorTest("encapsulated tasks work with native ES classes and decorators", function(assert) {


### PR DESCRIPTION
It was inadvertently removed when re-implementing encapsulated
tasks with Proxy. However, it's a useful feature for implementing
sort-of "higher-order tasks" and since there's no viable replacement,
this PR reintroduces it. It is, however, considered intimate,
undocumented API that will not be covered under SemVer guarantees.

Because it can be read from `this`, it can be accidentally overwritten
by user code. A future solution might be to provide some sort of
`getHostContext()` yieldable to provide the value within task execution
and avoid the need to access it directly.

For now, restoring it will allow folks who depended on such undocumented
behavior to upgrade to 2.0.0.