### PR TITLE
Prevent synchronous errors in cancelable promise helpers from being rethrown asynchronously later

### DIFF
--- a/addon/-private/cancelable-promise-helpers.js
+++ b/addon/-private/cancelable-promise-helpers.js
@@ -82,6 +82,16 @@ function taskAwareVariantOf(obj, method, getItems) {
   return function(thing) {
     let items = getItems(thing);
     assert(`'${method}' expects an array.`, Array.isArray(items));
+
+    items.forEach((it) => {
+      // Mark TaskInstances, including those that performed synchronously and
+      // have finished already, as having their errors handled, as if they had
+      // been then'd, which this is emulating.
+      if (it && it instanceof TaskInstance) {
+        it.executor.asyncErrorsHandled = true;
+      }
+    });
+
     let defer = RSVP.defer();
 
     obj[method](thing).then(defer.resolve, defer.reject);

--- a/addon/-private/external/task-instance/executor.js
+++ b/addon/-private/external/task-instance/executor.js
@@ -6,7 +6,6 @@ import {
   YIELDABLE_THROW,
   YIELDABLE_RETURN,
   YIELDABLE_CANCEL,
-  RawValue,
   cancelableSymbol
 } from '../yieldables';
 
@@ -231,11 +230,6 @@ export class TaskInstanceExecutor {
     let yieldedValue = stepResult.value;
     if (!yieldedValue) {
       this.proceedWithSimpleValue(yieldedValue);
-      return;
-    }
-
-    if (yieldedValue instanceof RawValue) {
-      this.proceedWithSimpleValue(yieldedValue.value);
       return;
     }
 

--- a/addon/-private/external/yieldables.js
+++ b/addon/-private/external/yieldables.js
@@ -159,16 +159,6 @@ export function animationFrame() {
  */
 export const forever = new ForeverYieldable();
 
-export class RawValue {
-  constructor(value) {
-    this.value = value;
-  }
-}
-
-export function raw(value) {
-  return new RawValue(value);
-}
-
 /**
  *
  * Yielding `rawTimeout(ms)` will pause a task for the duration


### PR DESCRIPTION
Fixes #400 