### PR TITLE
Add missing jsdoc documentation

### DIFF
--- a/.jsdoc
+++ b/.jsdoc
@@ -1,3 +1,12 @@
 {
-  "plugins": ["plugins/markdown"]
+  "opts": {
+    "destination": "tests/dummy/public/api/",
+    "readme": "API.md",
+    "recurse": true
+  },
+  "plugins": ["plugins/markdown"],
+  "source": {
+    "include": ["addon"]
+  },
+  "sourceType": "module"
 }

--- a/API.md
+++ b/API.md
@@ -27,6 +27,22 @@ export default class MyCompontent extends Component {
 });
 ```
 
+## Task Decorators
+
+You can find a description of all the Task Decorators
+under the [global API docs](global.html).
+
+- [task](global.html#task)
+- [restartableTask](global.html#restartableTask)
+- [enqueueTask](global.html#enqueueTask)
+- [drop](global.html#dropTask)
+- [keepLatest](global.html#keepLatestTask)
+- [taskGroup](global.html#taskGroup)
+- [restartableTaskGroup](global.html#restartableTaskGroup)
+- [enqueueTaskGroup](global.html#enqueueTaskGroup)
+- [dropGroup](global.html#dropTaskGroup)
+- [keepLatestGroup](global.html#keepLatestTaskGroup)
+
 ## Task Modifiers
 
 You can find a description of all the Task Modifiers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ This project uses `yarn` as a package manager. If you're adding a new dependency
 
 ### Running Tests
 
-* `yarn test:all` (Runs `ember try:each` to test your addon against multiple Ember versions)
+* `yarn test:ember-compatibility` (Runs `ember try:each` to test your addon against multiple Ember versions)
 * `ember test`
 * `ember test --server`
 
@@ -29,6 +29,5 @@ For more information on using ember-cli, visit [http://www.ember-cli.com/](http:
 ### Generate Docs
 
 TODO: use build pipeline.
-* `npm install -g jsdoc`
-* From addon root directory `./builddocs.sh`
+* From addon root directory `yarn docs:build`
 * View built docs in `tests/dummy/public/api`

--- a/addon/-private/task-decorators.js
+++ b/addon/-private/task-decorators.js
@@ -150,7 +150,7 @@ export const lastValue = decoratorWithParams((target, key, descriptor, [taskName
  * method.
  *
  * ```js
- * import Component from '@glimmer/component';
+ * import Component from '@ember/component';
  * import { task } from 'ember-concurrency';
  *
  * class MyComponent extends Component {
@@ -164,7 +164,7 @@ export const lastValue = decoratorWithParams((target, key, descriptor, [taskName
  *
  * @function
  * @param {object?} [options={}] Task modifier options
- * @param {string|string[]} [options.cancelOn] Events to cancel task on
+ * @param {string|string[]} [options.cancelOn] Events to cancel task on. Applies only to `&#64;ember/component`
  * @param {boolean} [options.enqueue] Sets `enqueue` modifier on task if `true`
  * @param {boolean} [options.evented] Enables [task lifecycle events](/docs/task-lifecycle-events) for this Task, if `true`
  * @param {boolean} [options.debug] Enables task debugging if `true`
@@ -173,7 +173,7 @@ export const lastValue = decoratorWithParams((target, key, descriptor, [taskName
  * @param {boolean} [options.keepLatest] Sets `keepLatest` modifier on task if `true`
  * @param {number} [options.maxConcurrency] Sets the maximum number of running task instances for the task
  * @param {string|string[]} [options.observes] Properties to watch and cause task to be performed when they change
- * @param {string|string[]} [options.on] Events to perform task on
+ * @param {string|string[]} [options.on] Events to perform task on. Applies only to `&#64;ember/component`
  * @param {function?} [options.onState] Callback to use for state tracking. May be set to `null` to disable state tracking.
  * @param {boolean} [options.restartable] Sets `restartable` modifier on task if `true`
  * @return {Task}
@@ -193,7 +193,7 @@ export const task = createDecorator(taskFromPropertyDescriptor);
  * method.
  *
  * ```js
- * import Component from '@glimmer/component';
+ * import Component from '@ember/component';
  * import { task, dropTask } from 'ember-concurrency';
  *
  * class MyComponent extends Component {
@@ -227,7 +227,7 @@ export const dropTask = createDecorator(
  * method.
  *
  * ```js
- * import Component from '@glimmer/component';
+ * import Component from '@ember/component';
  * import { task, enqueueTask } from 'ember-concurrency';
  *
  * class MyComponent extends Component {
@@ -261,7 +261,7 @@ export const enqueueTask = createDecorator(
  * method.
  *
  * ```js
- * import Component from '@glimmer/component';
+ * import Component from '@ember/component';
  * import { task, keepLatestTask } from 'ember-concurrency';
  *
  * class MyComponent extends Component {
@@ -295,7 +295,7 @@ export const keepLatestTask = createDecorator(
  * method.
  *
  * ```js
- * import Component from '@glimmer/component';
+ * import Component from '@ember/component';
  * import { task, restartableTask } from 'ember-concurrency';
  *
  * class MyComponent extends Component {

--- a/addon/-private/task-decorators.js
+++ b/addon/-private/task-decorators.js
@@ -128,37 +128,286 @@ export const lastValue = decoratorWithParams((target, key, descriptor, [taskName
   }
 });
 
+/**
+ * A Task is a cancelable, restartable, asynchronous operation that
+ * is driven by a generator function. Tasks are automatically canceled
+ * when the object they live on is destroyed (e.g. a Component
+ * is unrendered).
+ *
+ * Turns the decorated generator function into a task.
+ *
+ * Optionally takes a hash of options that will be applied as modifiers to the
+ * task. For instance `maxConcurrency`, `on`, `group` or `keepLatest`.
+ *
+ * By default, tasks have no concurrency constraints
+ * (multiple instances of a task can be running at the same time)
+ * but much of a power of tasks lies in proper usage of Task Modifiers
+ * that you can apply to a task.
+ *
+ * You can also define an
+ * <a href="/docs/encapsulated-task">Encapsulated Task</a>
+ * by decorating an object that defines a `perform` generator
+ * method.
+ *
+ * ```js
+ * import Component from '@glimmer/component';
+ * import { task } from 'ember-concurrency';
+ *
+ * class MyComponent extends Component {
+ *   &#64;task
+ *   *plainTask() {}
+ *
+ *   &#64;task({ maxConcurrency: 5, keepLatest: true, cancelOn: 'click' })
+ *   *taskWithModifiers() {}
+ * }
+ * ```
+ *
+ * @function
+ * @param {object?} [options={}] Task modifier options
+ * @param {string|string[]} [options.cancelOn] Events to cancel task on
+ * @param {boolean} [options.enqueue] Sets `enqueue` modifier on task if `true`
+ * @param {boolean} [options.evented] Enables [task lifecycle events](/docs/task-lifecycle-events) for this Task, if `true`
+ * @param {boolean} [options.debug] Enables task debugging if `true`
+ * @param {boolean} [options.drop] Sets `drop` modifier on task if `true`
+ * @param {string} [options.group] Associates task with the group specified
+ * @param {boolean} [options.keepLatest] Sets `keepLatest` modifier on task if `true`
+ * @param {number} [options.maxConcurrency] Sets the maximum number of running task instances for the task
+ * @param {string|string[]} [options.observes] Properties to watch and cause task to be performed when they change
+ * @param {string|string[]} [options.on] Events to perform task on
+ * @param {function?} [options.onState] Callback to use for state tracking. May be set to `null` to disable state tracking.
+ * @param {boolean} [options.restartable] Sets `restartable` modifier on task if `true`
+ * @return {Task}
+ */
 export const task = createDecorator(taskFromPropertyDescriptor);
+
+/**
+ * Turns the decorated generator function into a task and applies the
+ * `drop` modifier.
+ *
+ * Optionally takes a hash of options that will be applied as modifiers to the
+ * task. For instance `maxConcurrency`, `on`, or `group`.
+ *
+ * You can also define an
+ * <a href="/docs/encapsulated-task">Encapsulated Task</a>
+ * by decorating an object that defines a `perform` generator
+ * method.
+ *
+ * ```js
+ * import Component from '@glimmer/component';
+ * import { task, dropTask } from 'ember-concurrency';
+ *
+ * class MyComponent extends Component {
+ *   &#64;task
+ *   *plainTask() {}
+ *
+ *   &#64;dropTask({ cancelOn: 'click' })
+ *   *myDropTask() {}
+ * }
+ * ```
+ *
+ * @function
+ * @param {object?} [options={}] Task modifier options. See {@link task} for list.
+ * @return {Task}
+ */
 export const dropTask = createDecorator(
   taskFromPropertyDescriptor,
   { drop: true }
 );
+
+/**
+ * Turns the decorated generator function into a task and applies the
+ * `enqueue` modifier.
+ *
+ * Optionally takes a hash of options that will be applied as modifiers to the
+ * task. For instance `maxConcurrency`, `on`, or `group`.
+ *
+ * You can also define an
+ * <a href="/docs/encapsulated-task">Encapsulated Task</a>
+ * by decorating an object that defines a `perform` generator
+ * method.
+ *
+ * ```js
+ * import Component from '@glimmer/component';
+ * import { task, enqueueTask } from 'ember-concurrency';
+ *
+ * class MyComponent extends Component {
+ *   &#64;task
+ *   *plainTask() {}
+ *
+ *   &#64;enqueueTask({ cancelOn: 'click' })
+ *   *myEnqueueTask() {}
+ * }
+ * ```
+ *
+ * @function
+ * @param {object?} [options={}] Task modifier options. See {@link task} for list.
+ * @return {Task}
+ */
 export const enqueueTask = createDecorator(
   taskFromPropertyDescriptor,
   { enqueue: true }
 );
+
+/**
+ * Turns the decorated generator function into a task and applies the
+ * `keepLatest` modifier.
+ *
+ * Optionally takes a hash of options that will be applied as modifiers to the
+ * task. For instance `maxConcurrency`, `on`, or `group`.
+ *
+ * You can also define an
+ * <a href="/docs/encapsulated-task">Encapsulated Task</a>
+ * by decorating an object that defines a `perform` generator
+ * method.
+ *
+ * ```js
+ * import Component from '@glimmer/component';
+ * import { task, keepLatestTask } from 'ember-concurrency';
+ *
+ * class MyComponent extends Component {
+ *   &#64;task
+ *   *plainTask() {}
+ *
+ *   &#64;keepLatestTask({ cancelOn: 'click' })
+ *   *myKeepLatestTask() {}
+ * }
+ * ```
+ *
+ * @function
+ * @param {object?} [options={}] Task modifier options. See {@link task} for list.
+ * @return {Task}
+ */
 export const keepLatestTask = createDecorator(
   taskFromPropertyDescriptor,
   { keepLatest: true }
 );
+
+/**
+ * Turns the decorated generator function into a task and applies the
+ * `restartable` modifier.
+ *
+ * Optionally takes a hash of options that will be applied as modifiers to the
+ * task. For instance `maxConcurrency`, `on`, or `group`.
+ *
+ * You can also define an
+ * <a href="/docs/encapsulated-task">Encapsulated Task</a>
+ * by decorating an object that defines a `perform` generator
+ * method.
+ *
+ * ```js
+ * import Component from '@glimmer/component';
+ * import { task, restartableTask } from 'ember-concurrency';
+ *
+ * class MyComponent extends Component {
+ *   &#64;task
+ *   *plainTask() {}
+ *
+ *   &#64;restartableTask({ cancelOn: 'click' })
+ *   *myRestartableTask() {}
+ * }
+ * ```
+ *
+ * @function
+ * @param {object?} [options={}] Task modifier options. See {@link task} for list.
+ * @return {Task}
+ */
 export const restartableTask = createDecorator(
   taskFromPropertyDescriptor,
   { restartable: true }
 );
 
+/**
+ * "Task Groups" provide a means for applying
+ * task modifiers to groups of tasks. Once a {@linkcode Task} is declared
+ * as part of a group task, modifiers like `drop` or `restartable`
+ * will no longer affect the individual `Task`. Instead those
+ * modifiers can be applied to the entire group.
+ *
+ * Turns the decorated property into a task group.
+ *
+ * Optionally takes a hash of options that will be applied as modifiers to the
+ * task group. For instance `maxConcurrency` or `keepLatest`.
+ *
+ * ```js
+ * import Component from '@glimmer/component';
+ * import { task, taskGroup } from 'ember-concurrency';
+ *
+ * class MyComponent extends Component {
+ *   &#64;taskGroup({ maxConcurrency: 5 }) chores;
+ *
+ *   &#64;task({ group: 'chores' })
+ *   *mowLawn() {}
+ *
+ *   &#64;task({ group: 'chores' })
+ *   *doDishes() {}
+ * }
+ * ```
+ *
+ * @function
+ * @param {object?} [options={}] Task group modifier options. See {@link task} for list.
+ * @return {TaskGroup}
+ */
 export const taskGroup = createDecorator(taskGroupPropertyDescriptor);
+
+/**
+ * Turns the decorated property into a task group and applies the
+ * `drop` modifier.
+ *
+ * Optionally takes a hash of further options that will be applied as modifiers
+ * to the task group.
+ *
+ * @function
+ * @param {object?} [options={}] Task group modifier options. See {@link task} for list.
+ * @return {TaskGroup}
+ */
 export const dropTaskGroup = createDecorator(
   taskGroupPropertyDescriptor,
   { drop: true }
 );
+
+/**
+ * Turns the decorated property into a task group and applies the
+ * `enqueue` modifier.
+ *
+ * Optionally takes a hash of further options that will be applied as modifiers
+ * to the task group.
+ *
+ * @function
+ * @param {object?} [options={}] Task group modifier options. See {@link task} for list.
+ * @return {TaskGroup}
+ */
 export const enqueueTaskGroup = createDecorator(
   taskGroupPropertyDescriptor,
   { enqueue: true }
 );
+
+/**
+ * Turns the decorated property into a task group and applies the
+ * `keepLatest` modifier.
+ *
+ * Optionally takes a hash of further options that will be applied as modifiers
+ * to the task group.
+ *
+ * @function
+ * @param {object?} [options={}] Task group modifier options. See {@link task} for list.
+ * @return {TaskGroup}
+ */
 export const keepLatestTaskGroup = createDecorator(
   taskGroupPropertyDescriptor,
   { keepLatest: true }
 );
+
+/**
+ * Turns the decorated property into a task group and applies the
+ * `restartable` modifier.
+ *
+ * Optionally takes a hash of further options that will be applied as modifiers
+ * to the task group.
+ *
+ * @function
+ * @param {object?} [options={}] Task group modifier options. See {@link task} for list.
+ * @return {TaskGroup}
+ */
 export const restartableTaskGroup = createDecorator(
   taskGroupPropertyDescriptor,
   { restartable: true }

--- a/addon/-private/task-group.js
+++ b/addon/-private/task-group.js
@@ -2,7 +2,143 @@ import { TaskGroup as TaskGroupBase } from "./external/task/task-group";
 import { TASKABLE_MIXIN } from "./taskable-mixin";
 import { TRACKED_INITIAL_TASK_STATE } from "./tracked-state";
 
-export class TaskGroup extends TaskGroupBase { }
+export class TaskGroup extends TaskGroupBase {
+  /**
+   * Cancels all running or queued `TaskInstance`s for this task group.
+   * If you're trying to cancel a specific TaskInstance (rather
+   * than all of the instances running under this task group) call
+   * `.cancel()` on the specific TaskInstance.
+   *
+   * @method cancelAll
+   * @memberof TaskGroup
+   * @param options.reason A descriptive reason the task group was
+   *   cancelled. Defaults to `".cancelAll() was explicitly called
+   *   on the Task"`.
+   * @param options.resetState If true, will clear the task group state
+   *   (`last*` and `performCount` properties will be set to initial
+   *   values). Defaults to false.
+   * @instance
+   * @async
+   *
+   */
+
+     /**
+   * `true` if any current task instances are running.
+   *
+   * @memberof TaskGroup
+   * @member {boolean} isRunning
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * `true` if any future task instances are queued.
+   *
+   * @memberof TaskGroup
+   * @member {boolean} isQueued
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * `true` if the task is not in the running or queued state.
+   *
+   * @memberof TaskGroup
+   * @member {boolean} isIdle
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * The current state of the task: `"running"`, `"queued"` or `"idle"`.
+   *
+   * @memberof TaskGroup
+   * @member {string} state
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * The most recently started task instance.
+   *
+   * @memberof TaskGroup
+   * @member {TaskInstance} last
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * The most recent task instance that is currently running.
+   *
+   * @memberof TaskGroup
+   * @member {TaskInstance} lastRunning
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * The most recently performed task instance.
+   *
+   * @memberof TaskGroup
+   * @member {TaskInstance} lastPerformed
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * The most recent task instance that succeeded.
+   *
+   * @memberof TaskGroup
+   * @member {TaskInstance} lastSuccessful
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * The most recently completed task instance.
+   *
+   * @memberof TaskGroup
+   * @member {TaskInstance} lastComplete
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * The most recent task instance that errored.
+   *
+   * @memberof TaskGroup
+   * @member {TaskInstance} lastErrored
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * The most recently canceled task instance.
+   *
+   * @memberof TaskGroup
+   * @member {TaskInstance} lastCanceled
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * The most recent task instance that is incomplete.
+   *
+   * @memberof TaskGroup
+   * @member {TaskInstance} lastIncomplete
+   * @instance
+   * @readOnly
+   */
+
+  /**
+   * The number of times this task has been performed.
+   *
+   * @memberof TaskGroup
+   * @member {number} performCount
+   * @instance
+   * @readOnly
+   */
+}
 
 if (TRACKED_INITIAL_TASK_STATE) {
   Object.defineProperties(TaskGroup.prototype, TRACKED_INITIAL_TASK_STATE);

--- a/addon/-private/task-instance.js
+++ b/addon/-private/task-instance.js
@@ -15,12 +15,8 @@ import { assignProperties } from "./utils";
   because concurrency policy enforced by a
   {@linkcode TaskProperty Task Modifier} canceled the task instance.
 
-  <style>
-    .ignore-this--this-is-here-to-hide-constructor,
-    #TaskInstance { display: none }
-  </style>
-
   @class TaskInstance
+  @hideconstructor
 */
 
 export class TaskInstance extends BaseTaskInstance {
@@ -117,7 +113,7 @@ export class TaskInstance extends BaseTaskInstance {
    *     because the task is using the {@linkcode TaskProperty#enqueue enqueue}
    *     task modifier)
    *
-   * The animated timeline examples on the [Task Concurrency](/#/docs/task-concurrency)
+   * The animated timeline examples on the [Task Concurrency](/docs/task-concurrency)
    * docs page make use of this property.
    *
    * @name state
@@ -242,6 +238,7 @@ export class TaskInstance extends BaseTaskInstance {
    * @method cancel
    * @memberof TaskInstance
    * @instance
+   * @async
    */
 
   /**

--- a/addon/-private/task.js
+++ b/addon/-private/task.js
@@ -25,13 +25,8 @@ import { CANCEL_KIND_LIFESPAN_END } from "./external/task-instance/cancelation";
   method on this object to cancel all running or enqueued
   {@linkcode TaskInstance}s.
 
-
-  <style>
-    .ignore-this--this-is-here-to-hide-constructor,
-    #Task{ display: none }
-  </style>
-
   @class Task
+  @hideconstructor
 */
 export class Task extends BaseTask {
   constructor(options) {
@@ -90,6 +85,25 @@ export class Task extends BaseTask {
    * @fires TaskInstance#TASK_NAME:succeeded
    * @fires TaskInstance#TASK_NAME:errored
    * @fires TaskInstance#TASK_NAME:canceled
+   *
+   */
+
+  /**
+   * Cancels all running or queued `TaskInstance`s for this Task.
+   * If you're trying to cancel a specific TaskInstance (rather
+   * than all of the instances running under this task) call
+   * `.cancel()` on the specific TaskInstance.
+   *
+   * @method cancelAll
+   * @memberof Task
+   * @param options.reason A descriptive reason the task was
+   *   cancelled. Defaults to `".cancelAll() was explicitly called
+   *   on the Task"`.
+   * @param options.resetState If true, will clear the task state
+   *   (`last*` and `performCount` properties will be set to initial
+   *   values). Defaults to false.
+   * @instance
+   * @async
    *
    */
 

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -335,7 +335,7 @@ export interface TaskInstance<T> extends Promise<T> {
    *     because the task is using the {@linkcode TaskProperty#enqueue enqueue}
    *     task modifier)
    *
-   * The animated timeline examples on the [Task Concurrency](/#/docs/task-concurrency)
+   * The animated timeline examples on the [Task Concurrency](/docs/task-concurrency)
    * docs page make use of this property.
    */
   readonly state: 'dropped' | 'canceled' | 'finished' | 'running' | 'waiting';
@@ -407,7 +407,7 @@ interface AbstractTaskProperty<T extends Task<any, any[]>> extends ComputedPrope
    * });
    * ```
    *
-   * [See the Writing Tasks Docs for more info](/#/docs/writing-tasks)
+   * [See the Writing Tasks Docs for more info](/docs/writing-tasks)
    */
   on(...eventNames: string[]): this;
 
@@ -416,7 +416,7 @@ interface AbstractTaskProperty<T extends Task<any, any[]>> extends ComputedPrope
    * but instead will cause the task to be canceled if any of the
    * specified events fire on the parent object.
    *
-   * [See the Live Example](/#/docs/examples/route-tasks/1)
+   * [See the Live Example](/docs/examples/route-tasks/1)
    */
   cancelOn(...eventNames: string[]): this;
 
@@ -432,7 +432,7 @@ interface AbstractTaskProperty<T extends Task<any, any[]>> extends ComputedPrope
    * to make room for a new one to perform. Sets default
    * maxConcurrency to 1.
    *
-   * [See the Live Example](/#/docs/examples/route-tasks/1)
+   * [See the Live Example](/docs/examples/route-tasks/1)
    */
   restartable(): this;
 
@@ -468,7 +468,7 @@ interface AbstractTaskProperty<T extends Task<any, any[]>> extends ComputedPrope
    * to set the maximum number of concurrently running tasks
    * to a number greater than 1.
    *
-   * [See the AJAX Throttling example](/#/docs/examples/ajax-throttling)
+   * [See the AJAX Throttling example](/docs/examples/ajax-throttling)
    *
    * The example below uses a task with `maxConcurrency(3)` to limit
    * the number of concurrent AJAX requests (for anyone using this task)
@@ -492,7 +492,7 @@ interface AbstractTaskProperty<T extends Task<any, any[]>> extends ComputedPrope
    * Adds this task to a TaskGroup so that concurrency constraints
    * can be shared between multiple tasks.
    *
-   * [See the Task Group docs for more information](/#/docs/task-groups)
+   * [See the Task Group docs for more information](/docs/task-groups)
    *
    * @param groupPath A path to the TaskGroup property.
    */
@@ -530,7 +530,7 @@ interface AbstractTaskProperty<T extends Task<any, any[]>> extends ComputedPrope
  * from the {@linkcode task} function. You can call Task Modifier methods
  * on this object to configure the behavior of the {@link Task}.
  *
- * See [Managing Task Concurrency](/#/docs/task-concurrency) for an
+ * See [Managing Task Concurrency](/docs/task-concurrency) for an
  * overview of all the different task modifiers you can use and how
  * they impact automatic cancelation / enqueueing of task instances.
  */
@@ -551,7 +551,7 @@ export interface TaskGroupProperty<T> extends ComputedProperty<TaskGroup<T>> {
    * instances to make room for a new one to perform. Sets
    * default maxConcurrency to 1.
    *
-   * [See the Live Example](/#/docs/examples/route-tasks/1)
+   * [See the Live Example](/docs/examples/route-tasks/1)
    *
    * @method restartable
    * @memberof TaskGroupProperty
@@ -605,7 +605,7 @@ export interface TaskGroupProperty<T> extends ComputedProperty<TaskGroup<T>> {
    * value to set the maximum number of concurrently running
    * tasks to a number greater than 1.
    *
-   * [See the AJAX Throttling example](/#/docs/examples/ajax-throttling)
+   * [See the AJAX Throttling example](/docs/examples/ajax-throttling)
    *
    * The example below uses a task group with `maxConcurrency(3)`
    * to limit the number of concurrent AJAX requests (for anyone

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -797,7 +797,7 @@ export function task<T extends EncapsulatedTaskDescriptor<any, any[]>>(taskFn: T
  * method.
  *
  * ```js
- * import Component from '@glimmer/component';
+ * import Component from '@ember/component';
  * import { task, dropTask } from 'ember-concurrency';
  *
  * class MyComponent extends Component {
@@ -838,7 +838,7 @@ export function dropTask(
  * method.
  *
  * ```js
- * import Component from '@glimmer/component';
+ * import Component from '@ember/component';
  * import { task, enqueueTask } from 'ember-concurrency';
  *
  * class MyComponent extends Component {
@@ -879,7 +879,7 @@ export function enqueueTask(
  * method.
  *
  * ```js
- * import Component from '@glimmer/component';
+ * import Component from '@ember/component';
  * import { task, keepLatestTask } from 'ember-concurrency';
  *
  * class MyComponent extends Component {
@@ -920,7 +920,7 @@ export function keepLatestTask(
  * method.
  *
  * ```js
- * import Component from '@glimmer/component';
+ * import Component from '@ember/component';
  * import { task, restartableTask } from 'ember-concurrency';
  *
  * class MyComponent extends Component {

--- a/builddocs.sh
+++ b/builddocs.sh
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-jsdoc \
-  addon/* \
-  addon/-private/external/* \
-  -R API.md \
-  -c .jsdoc \
-  -d tests/dummy/public/api/

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,11 +1,1 @@
-{
-  "compilerOptions": { "target": "es6", "experimentalDecorators": true },
-  "exclude": [
-    "node_modules",
-    "bower_components",
-    "tmp",
-    "vendor",
-    ".git",
-    "dist"
-  ]
-}
+{"compilerOptions":{"target":"es6","experimentalDecorators":true},"exclude":["node_modules","bower_components","tmp","vendor",".git","dist"]}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Improved concurrency/async primitives for Ember.js",
   "scripts": {
     "build": "ember build --environment=production",
+    "docs:build": "node_modules/.bin/jsdoc -c .jsdoc --verbose",
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
@@ -66,6 +67,7 @@
     "eslint-plugin-ember": "^9.3.0",
     "eslint-plugin-node": "^11.1.0",
     "expect-type": "^0.7.4",
+    "jsdoc": "^3.6.6",
     "jsdom": "^11.6.2",
     "loader.js": "^4.7.0",
     "npm-run-all": "^4.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -260,6 +260,11 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.3.tgz#a305415ebe7a6c7023b40b5122a0662d928334cd"
   integrity sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==
 
+"@babel/parser@^7.9.4":
+  version "7.13.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.13.4.tgz#340211b0da94a351a6f10e63671fa727333d13ab"
+  integrity sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==
+
 "@babel/plugin-proposal-async-generator-functions@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.12.1.tgz#dc6c1170e27d8aca99ff65f4925bd06b1c90550e"
@@ -3232,7 +3237,7 @@ bluebird@^2.9.33:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
   integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
 
-bluebird@^3.1.1, bluebird@^3.4.6, bluebird@^3.5.5:
+bluebird@^3.1.1, bluebird@^3.4.6, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -4195,6 +4200,13 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
+catharsis@^0.8.11:
+  version "0.8.11"
+  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.11.tgz#d0eb3d2b82b7da7a3ce2efb1a7b00becc6643468"
+  integrity sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==
+  dependencies:
+    lodash "^4.17.14"
 
 ccount@^1.0.0:
   version "1.0.4"
@@ -6482,6 +6494,11 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
+escape-string-regexp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
+  integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
 escodegen@^1.11.0, escodegen@^1.8.1, escodegen@^1.9.1:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.12.0.tgz#f763daf840af172bb3a2b6dd7219c0e17f7ff541"
@@ -8019,6 +8036,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
+graceful-fs@^4.1.9:
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
+
 graceful-fs@~1.2.0:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-1.2.3.tgz#15a4806a57547cb2d2dbf27f42e89a8c3451b364"
@@ -9065,6 +9087,13 @@ js-yaml@^3.13.1, js-yaml@^3.2.5, js-yaml@^3.2.7, js-yaml@^3.3.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js2xmlparser@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-4.0.1.tgz#670ef71bc5661f089cc90481b99a05a1227ae3bd"
+  integrity sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==
+  dependencies:
+    xmlcreate "^2.0.3"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
@@ -9074,6 +9103,26 @@ jsdoc-inline-lex@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/jsdoc-inline-lex/-/jsdoc-inline-lex-1.0.1.tgz#ac0b4d11b904bdfbd9bdf889bb433de5c3839800"
   integrity sha1-rAtNEbkEvfvZvfiJu0M95cODmAA=
+
+jsdoc@^3.6.6:
+  version "3.6.6"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.6.6.tgz#9fe162bbdb13ee7988bf74352b5147565bcfd8e1"
+  integrity sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==
+  dependencies:
+    "@babel/parser" "^7.9.4"
+    bluebird "^3.7.2"
+    catharsis "^0.8.11"
+    escape-string-regexp "^2.0.0"
+    js2xmlparser "^4.0.1"
+    klaw "^3.0.0"
+    markdown-it "^10.0.0"
+    markdown-it-anchor "^5.2.7"
+    marked "^0.8.2"
+    mkdirp "^1.0.4"
+    requizzle "^0.2.3"
+    strip-json-comments "^3.1.0"
+    taffydb "2.6.2"
+    underscore "~1.10.2"
 
 jsdom@^11.6.2:
   version "11.12.0"
@@ -9302,6 +9351,13 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.2.tgz#01146b36a6218e64e58f3a8d66de5d7fc6f6d051"
   integrity sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==
+
+klaw@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-3.0.0.tgz#b11bec9cf2492f06756d6e809ab73a2910259146"
+  integrity sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==
+  dependencies:
+    graceful-fs "^4.1.9"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -10121,6 +10177,11 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+markdown-it-anchor@^5.2.7:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz#d549acd64856a8ecd1bea58365ef385effbac744"
+  integrity sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==
+
 markdown-it-terminal@0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/markdown-it-terminal/-/markdown-it-terminal-0.2.1.tgz#670fd5ea824a7dcaa1591dcbeef28bf70aff1705"
@@ -10131,6 +10192,17 @@ markdown-it-terminal@0.2.1:
     cli-table "^0.3.1"
     lodash.merge "^4.6.2"
     markdown-it "^8.3.1"
+
+markdown-it@^10.0.0:
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-10.0.0.tgz#abfc64f141b1722d663402044e43927f1f50a8dc"
+  integrity sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==
+  dependencies:
+    argparse "^1.0.7"
+    entities "~2.0.0"
+    linkify-it "^2.0.0"
+    mdurl "^1.0.1"
+    uc.micro "^1.0.5"
 
 markdown-it@^11.0.0:
   version "11.0.1"
@@ -10158,6 +10230,11 @@ markdown-table@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-0.4.0.tgz#890c2c1b3bfe83fb00e4129b8e4cfe645270f9d1"
   integrity sha1-iQwsGzv+g/sA5BKbjkz+ZFJw+dE=
+
+marked@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
+  integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
 
 matcher-collection@^1.0.0, matcher-collection@^1.1.1:
   version "1.1.2"
@@ -12562,6 +12639,13 @@ requires-port@^1.0.0:
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
   integrity sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=
 
+requizzle@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.3.tgz#4675c90aacafb2c036bd39ba2daa4a1cb777fded"
+  integrity sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==
+  dependencies:
+    lodash "^4.17.14"
+
 reselect@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/reselect/-/reselect-3.0.1.tgz#efdaa98ea7451324d092b2b2163a6a1d7a9a2147"
@@ -13747,6 +13831,11 @@ table@^5.2.3:
     slice-ansi "^2.1.0"
     string-width "^3.0.0"
 
+taffydb@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
+  integrity sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=
+
 tap-parser@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-7.0.0.tgz#54db35302fda2c2ccc21954ad3be22b2cba42721"
@@ -14279,6 +14368,11 @@ underscore@>=1.8.3:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.9.1.tgz#06dce34a0e68a7babc29b365b8e74b8925203961"
   integrity sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==
+
+underscore@~1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.10.2.tgz#73d6aa3668f3188e4adb0f1943bd12cfd7efaaaf"
+  integrity sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==
 
 unherit@^1.0.0, unherit@^1.0.4:
   version "1.1.2"
@@ -15003,6 +15097,11 @@ xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+
+xmlcreate@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-2.0.3.tgz#df9ecd518fd3890ab3548e1b811d040614993497"
+  integrity sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==
 
 xmldom@^0.1.19:
   version "0.1.27"


### PR DESCRIPTION
In moving stuff around, some methods such as `cancelAll` got lost in the jsdoc documentation. Went through and made sure all public API was adequately documented in jsdoc.

h/t @Turbo87 for the heads up on the `cancelAll` and @bendemboski who noticed `onState` hadn't been documented