### PR TITLE
Correctly import from private task-instance

### DIFF
--- a/addon/-task-instance.js
+++ b/addon/-task-instance.js
@@ -1,4 +1,4 @@
-import TaskInstance from './-private/task-instance';
+import { TaskInstance } from './-private/task-instance';
 import { deprecatePrivateModule } from './-private/utils';
 deprecatePrivateModule("ember-concurrency/-task-instance");
 export default TaskInstance;

--- a/addon/index.js
+++ b/addon/index.js
@@ -5,7 +5,7 @@ import {
   task,
   taskGroup
 } from './-private/task-properties';
-import { default as TaskInstance } from './-private/task-instance';
+import { TaskInstance } from './-private/task-instance';
 import {
   all,
   allSettled,


### PR DESCRIPTION
In my typescript app I noticed these warnings:

```
WARNING in ./node_modules/ember-concurrency/-task-instance.js 4:15-27
"export 'default' (imported as 'TaskInstance') was not found in './-private/task-instance'
@ ./assets/my-app.js
    
WARNING in ./node_modules/ember-concurrency/index.js 11:0-378
"export 'default' (reexported as 'TaskInstance') was not found in './-private/task-instance'
@ ./node_modules/ember-power-select/components/power-select.js
@ ./assets/my-app.js
```

So I went and looked, and it seems they were incorrectly importing the default instead of named export. I guess this isn't used anywhere, as otherwise it should have broken (?) somehow. I fixed the imports here.