### PR TITLE
RFC: Public Yieldables API

### DIFF
--- a/addon/-private/external/yieldables.js
+++ b/addon/-private/external/yieldables.js
@@ -25,7 +25,7 @@ export class Yieldable {
     );
   }
 
-  continue(value) {
+  next(value) {
     let taskInstance = this[instanceSymbol];
     taskInstance.proceed.call(
       taskInstance,
@@ -116,7 +116,7 @@ class AnimationFrameYieldable extends Yieldable {
   }
 
   onYield() {
-    this.timerId = requestAnimationFrame(() => this.continue());
+    this.timerId = requestAnimationFrame(() => this.next());
   }
 
   onDispose() {
@@ -139,7 +139,7 @@ class RawTimeoutYieldable extends Yieldable {
   }
 
   onYield() {
-    this.timerId = setTimeout(() => this.continue(), this.ms);
+    this.timerId = setTimeout(() => this.next(), this.ms);
   }
 
   onDispose() {

--- a/addon/-private/task-instance.js
+++ b/addon/-private/task-instance.js
@@ -15,8 +15,12 @@ import { assignProperties } from "./utils";
   because concurrency policy enforced by a
   {@linkcode TaskProperty Task Modifier} canceled the task instance.
 
+  <style>
+    .ignore-this--this-is-here-to-hide-constructor,
+    #TaskInstance { display: none }
+  </style>
+
   @class TaskInstance
-  @hideconstructor
 */
 
 export class TaskInstance extends BaseTaskInstance {

--- a/addon/-private/task.js
+++ b/addon/-private/task.js
@@ -25,8 +25,12 @@ import { CANCEL_KIND_LIFESPAN_END } from "./external/task-instance/cancelation";
   method on this object to cancel all running or enqueued
   {@linkcode TaskInstance}s.
 
+  <style>
+    .ignore-this--this-is-here-to-hide-constructor,
+    #Task { display: none }
+  </style>
+
   @class Task
-  @hideconstructor
 */
 export class Task extends BaseTask {
   constructor(options) {

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -2,12 +2,7 @@ import { setProperties } from '@ember/object';
 import { later, cancel } from '@ember/runloop';
 import { gte } from 'ember-compatibility-helpers';
 import { EMBER_ENVIRONMENT } from "./ember-environment";
-import {
-  Yieldable,
-  yieldableSymbol,
-  YIELDABLE_CONTINUE,
-  cancelableSymbol
-} from "./external/yieldables";
+import { Yieldable } from "./external/yieldables";
 
 export const USE_TRACKED = gte('3.16.0');
 export const assignProperties = USE_TRACKED ? Object.assign : setProperties;
@@ -33,13 +28,11 @@ class TimeoutYieldable extends EmberYieldable {
     this.timerId = null;
   }
 
-  [yieldableSymbol](taskInstance, resumeIndex) {
-    this.timerId = later(() => {
-      taskInstance.proceed(resumeIndex, YIELDABLE_CONTINUE, taskInstance._result);
-    }, this.ms);
+  onYield() {
+    this.timerId = later(() => this.continue(), this.ms);
   }
 
-  [cancelableSymbol]() {
+  onDispose() {
     cancel(this.timerId);
     this.timerId = null;
   }

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -29,7 +29,7 @@ class TimeoutYieldable extends EmberYieldable {
   }
 
   onYield() {
-    this.timerId = later(() => this.continue(), this.ms);
+    this.timerId = later(() => this.next(), this.ms);
   }
 
   onDispose() {

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -25,16 +25,12 @@ class TimeoutYieldable extends EmberYieldable {
   constructor(ms) {
     super();
     this.ms = ms;
-    this.timerId = null;
   }
 
-  onYield() {
-    this.timerId = later(() => this.next(), this.ms);
-  }
+  onYield(taskInstance) {
+    let timerId = later(() => this.next(taskInstance), this.ms);
 
-  onDispose() {
-    cancel(this.timerId);
-    this.timerId = null;
+    return () => cancel(timerId);
   }
 }
 

--- a/addon/-private/utils.js
+++ b/addon/-private/utils.js
@@ -27,8 +27,8 @@ class TimeoutYieldable extends EmberYieldable {
     this.ms = ms;
   }
 
-  onYield(taskInstance) {
-    let timerId = later(() => this.next(taskInstance), this.ms);
+  onYield(state) {
+    let timerId = later(() => state.next(), this.ms);
 
     return () => cancel(timerId);
   }

--- a/addon/-private/wait-for.js
+++ b/addon/-private/wait-for.js
@@ -10,13 +10,13 @@ class WaitForQueueYieldable extends EmberYieldable {
     this.queueName = queueName;
   }
 
-  onYield(taskInstance) {
+  onYield(state) {
     let timerId;
 
     try {
-      timerId = schedule(this.queueName, () => this.next(taskInstance));
+      timerId = schedule(this.queueName, () => state.next());
     } catch(error) {
-      this.throw(taskInstance, error);
+      state.throw(error);
     }
 
     return () => cancel(timerId);
@@ -49,7 +49,7 @@ class WaitForEventYieldable extends EmberYieldable {
     }
   }
 
-  onYield(taskInstance) {
+  onYield(state) {
     let fn = null;
     let disposer = () => {
       fn && this.off(fn);
@@ -58,7 +58,7 @@ class WaitForEventYieldable extends EmberYieldable {
 
     fn = (event) => {
       disposer();
-      this.next(taskInstance, event);
+      state.next(event);
     };
 
     this.on(fn);
@@ -80,13 +80,13 @@ class WaitForPropertyYieldable extends EmberYieldable {
     }
   }
 
-  onYield(taskInstance) {
+  onYield(state) {
     let observerBound = false;
     let observerFn = () => {
       let value = get(this.object, this.key);
       let predicateValue = this.predicateCallback(value);
       if (predicateValue) {
-        this.next(taskInstance, value);
+        state.next(value);
         return true;
       }
     };

--- a/addon/-private/wait-for.js
+++ b/addon/-private/wait-for.js
@@ -13,7 +13,7 @@ class WaitForQueueYieldable extends EmberYieldable {
 
   onYield() {
     try {
-      this.timerId = schedule(this.queueName, () => this.continue());
+      this.timerId = schedule(this.queueName, () => this.next());
     } catch(error) {
       this.throw(error);
     }
@@ -40,7 +40,7 @@ class WaitForEventYieldable extends EmberYieldable {
     this.fn = (event) => {
       this.didFinish = true;
       this.onDispose();
-      this.continue(event);
+      this.next(event);
     };
 
     if (typeof this.object.addEventListener === "function") {
@@ -93,7 +93,7 @@ class WaitForPropertyYieldable extends EmberYieldable {
       let value = get(this.object, this.key);
       let predicateValue = this.predicateCallback(value);
       if (predicateValue) {
-        this.continue(value);
+        this.next(value);
         return true;
       }
     };

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,4 +1,4 @@
-import { timeout } from './-private/utils';
+import { timeout, EmberYieldable as Yieldable } from './-private/utils';
 import {
   TaskProperty,
   TaskGroupProperty,
@@ -67,5 +67,6 @@ export {
   TaskProperty,
   TaskInstance,
   TaskGroup,
-  TaskGroupProperty
+  TaskGroupProperty,
+  Yieldable
 };

--- a/rfcs/0000-yieldables.md
+++ b/rfcs/0000-yieldables.md
@@ -74,16 +74,16 @@ class YieldableState {
   return(value: any): void;
 
   // Raise a given error within the given task instance and halt execution
-  throw(error: Error): void;
+  throw(error: any): void;
 }
 
-abstract class Yieldable {
+abstract class Yieldable<T> implements PromiseLike<T> {
   constructor(...args) {
     // User setup logic would go here. If the yieldable took arguments, they
     // could be stored in the Yieldable here
   }
 
-  onYield(state: YieldableState): Function<void> {
+  onYield(state: YieldableState): () => void {
     // This is where most user code would go, defining what happens when the
     // task encounters `yield myYieldable`.
 

--- a/rfcs/0000-yieldables.md
+++ b/rfcs/0000-yieldables.md
@@ -1,0 +1,179 @@
+---
+Stage: Accepted
+Start Date: 2021-03-07
+Release Date: Unreleased
+Release Versions:
+  ember-concurrency: vX.Y.Z
+RFC PR: 
+---
+
+<!--- 
+Directions for above: 
+
+Stage: Leave as is
+Start Date: Fill in with today's date, YYYY-MM-DD
+Release Date: Leave as is
+Release Versions: Leave as is
+RFC PR: Fill this in with the URL for the Proposal RFC PR
+-->
+
+# Yieldables
+
+## Summary
+
+Promote Yieldables to public API, as a way to instrument TaskInstances by
+providing a safe mechanism to implement custom waiters, hooks, introspection,
+and other operations in a task definition, from application code.
+
+## Motivation
+
+> Why are we doing this? What use cases does it support? What is the expected
+> outcome?
+
+There are many great uses for yieldables, and indeed many of them are already
+built-in to ember-concurrency today. Yieldables like `timeout`, `animationFrame`,
+and `rawTimeout` provide safe, cancelation-aware ways to delay execution of a
+task. Cancelable Promise helpers like `all`, and `hashSettled` are too a form of
+yieldable.
+
+While there are many built-in forms that provide cancelation-aware wrappers around
+common browser APIs, there's a great opportunity for an ecosystem of yieldables,
+based on domain-specific yieldables defined by users within their applications,
+and supporting yieldables defined by complementary addons, in order to implement
+behavior that would be inappropriate for inclusion in the main `ember-concurrency`
+addon.
+
+The expected outcome is that users and addon creators alike would be empowered
+to experiment with new ways to control and introspect the task runtime, without
+having to learn all about the ember-concurrency internals or waiting for
+maintainers to try out their feature suggestions.
+
+## Detailed design
+
+Yieldables already exists in ember-concurrency in a similar form, but the
+proposal would be to elevate this to a public API and add a little bit more
+hiding of internals to avoid the need for users to know intimate details about
+how to hand control back to the task.
+
+The API proposed is fairly simple:
+
+```javascript
+class Yieldable {
+  constructor(arg1, arg2, arg3, ...) {
+    super(...arguments);
+    // User setup logic would go here. If the yieldable took arguments, they
+    // could be store in the Yieldable here
+  }
+
+  onYield(taskInstance) {
+    // This is where most user code would go, defining what happens when the
+    // task encounters `yield myYieldable`.
+
+    // The user would have three methods they can call within here:
+    // * this.next(value) - would could cause the yield to return with an
+    //   optional value, and continue executing the task instance
+    // * this.return(value) - would short-cirsuit task execution and have it
+    //   return with an optional value.
+    // * this.throw(error) - would raise a given error within the task instance
+    //   and halt execution
+  }
+
+  onDispose() {
+    // Custom dispose logic goes here. Would be called if task was canceled or
+    // upon completion. Things like `cancelTimeout`, timer cleanup, or property
+    // resets might happen here.
+  }
+}
+```
+
+For example, if I wanted to implement a yieldable for `requestIdleCallback`, I
+could do the following:
+
+```javascript
+import Component from '@glimmer/component';
+import { task, Yieldable } from 'ember-concurrency';
+
+class IdleCallbackYieldable extends Yieldable {
+  onYield() {
+    this.callbackId = requestIdleCallback(() => this.continue());
+  }
+
+  onDispose() {
+    cancelIdleCallback(this.callbackId);
+    this.callbackId = null;
+  }
+}
+
+function idleCallback() {
+  return new IdleCallbackYieldable();
+}
+
+class MyComponent extends Component {
+  @task *backgroundTask() {
+    yield idleCallback();
+
+    const data = this.complicatedNumberCrunching();
+    yield this.sendData(data);
+  }
+}
+```
+
+In general, `Yieldable` instances **should not** be reused across calls, and
+thus care should be taken to ensure that users create a function, like `idleCallback`
+above, to provide a new instance on every call.
+
+## How we teach this
+
+> What names and terminology work best for these concepts and why? How is this
+> idea best presented? As a continuation of existing ember-concurrency patterns,
+> or as a wholly new one?
+
+We've called these yieldables internally for quite a while and I think it's a
+relatively concise term for them, but am open to better suggestions.
+
+> Would the acceptance of this proposal mean the ember-concurrency guides must be
+> re-organized or altered? Does it change how ember-concurrency is taught to new
+> users at any level?
+
+We'd probably want to add a new docs page, maybe under some sort of "advanced"
+section about extending ember-concurrency. It's probably not something for folks
+just starting with ember-concurrency, but a useful tool to try later when they've
+gotten the hang of things.
+
+> How should this feature be introduced and taught to existing ember-concurrency
+> users?
+
+Introduce a docs page that illustrates the creation of a new yieldable and
+explains how it ties in with cancelation/teardown, etc.
+
+## Drawbacks
+
+> Why should we *not* do this? Please consider the impact on teaching Ember,
+> on the integration of this feature with other existing and planned features,
+> on the impact of the API churn on existing apps, etc.
+
+* Adds _slightly_ to the footprint of `ember-concurrency`'s public API
+
+> There are tradeoffs to choosing any path, please attempt to identify them here.
+
+* Potential footgun if used incorrectly (e.g. not doing teardown properly)
+
+## Alternatives
+
+> What other designs have been considered? What is the impact of not doing this?
+> This section could also include prior art, that is, how other frameworks in the
+> same domain have solved this problem.
+
+It might be possible to provide a more functional approach, with a disposer being
+returned by the function (many yieldables were first implemented this way), but
+this complicates or precludes certain use cases. However, I think a functional
+approach would remain available later. See Ember helpers and modifiers as an
+example that allows both functional and class-based implementations.
+
+## Unresolved questions
+
+> Optional, but suggested for first drafts. What parts of the design are still
+> TBD?
+
+* Is providing access to `taskInstance` too unsafe, and a potential footgun? Is
+  this something to worry about?

--- a/rfcs/0000-yieldables.md
+++ b/rfcs/0000-yieldables.md
@@ -4,7 +4,7 @@ Start Date: 2021-03-07
 Release Date: Unreleased
 Release Versions:
   ember-concurrency: vX.Y.Z
-RFC PR: 
+RFC PR: https://github.com/machty/ember-concurrency/pull/413
 ---
 
 <!--- 

--- a/rfcs/0000-yieldables.md
+++ b/rfcs/0000-yieldables.md
@@ -95,7 +95,7 @@ import { task, Yieldable } from 'ember-concurrency';
 
 class IdleCallbackYieldable extends Yieldable {
   onYield() {
-    this.callbackId = requestIdleCallback(() => this.continue());
+    this.callbackId = requestIdleCallback(() => this.next());
   }
 
   onDispose() {

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -38,7 +38,8 @@ import {
   waitForEvent,
   waitForProperty,
   waitForQueue,
-  lastValue
+  lastValue,
+  Yieldable
 } from 'ember-concurrency';
 import { taskFor } from 'ember-concurrency-ts';
 import { expectTypeOf as expect } from 'expect-type';
@@ -2077,7 +2078,7 @@ module('unit tests', () => {
   test('timeout', async () => {
     expect(timeout).toBeCallableWith(500);
     expect(timeout).parameters.toEqualTypeOf<[number]>();
-    expect(timeout).returns.toEqualTypeOf<PromiseLike<void>>();
+    expect(timeout).returns.toEqualTypeOf<Yieldable<void>>();
 
     // @ts-expect-error
     timeout();
@@ -2097,7 +2098,7 @@ module('unit tests', () => {
   test('rawTimeout', async () => {
     expect(rawTimeout).toBeCallableWith(500);
     expect(rawTimeout).parameters.toEqualTypeOf<[number]>();
-    expect(rawTimeout).returns.toEqualTypeOf<PromiseLike<void>>();
+    expect(rawTimeout).returns.toEqualTypeOf<Yieldable<void>>();
 
     // @ts-expect-error
     rawTimeout();
@@ -2117,7 +2118,7 @@ module('unit tests', () => {
   test('animationFrame', async () => {
     expect(animationFrame).toBeCallableWith();
     expect(animationFrame).parameters.toEqualTypeOf<[]>();
-    expect(animationFrame).returns.toEqualTypeOf<PromiseLike<void>>();
+    expect(animationFrame).returns.toEqualTypeOf<Yieldable<void>>();
 
     // @ts-expect-error
     animationFrame('nope');
@@ -2134,7 +2135,7 @@ module('unit tests', () => {
   test('waitForQueue', async () => {
     expect(waitForQueue).toBeCallableWith('afterRender');
     expect(waitForQueue).parameters.toEqualTypeOf<[string]>();
-    expect(waitForQueue).returns.toEqualTypeOf<PromiseLike<void>>();
+    expect(waitForQueue).returns.toEqualTypeOf<Yieldable<void>>();
 
     // @ts-expect-error
     waitForQueue();
@@ -2179,7 +2180,7 @@ module('unit tests', () => {
     }, 'foo');
     expect(waitForEvent).toBeCallableWith(document.body, 'click');
     expect(waitForEvent).parameters.toEqualTypeOf<[Evented, string]>();
-    expect(waitForEvent).returns.toEqualTypeOf<PromiseLike<void>>();
+    expect(waitForEvent).returns.toEqualTypeOf<Yieldable<void>>();
 
     // @ts-expect-error
     waitForEvent();
@@ -2204,7 +2205,7 @@ module('unit tests', () => {
     expect(waitForProperty).toBeCallableWith(obj, 'foo', (v: string) => v === 'bar');
 
     expect(waitForProperty).parameters.toEqualTypeOf<[object, string | number | symbol, unknown]>();
-    expect(waitForProperty).returns.toEqualTypeOf<PromiseLike<void>>();
+    expect(waitForProperty).returns.toEqualTypeOf<Yieldable<void>>();
 
     // @ts-expect-error
     waitForProperty();
@@ -2233,7 +2234,7 @@ module('unit tests', () => {
   test('forever', async () => {
     expect(forever).toBeCallableWith();
     expect(forever).parameters.toEqualTypeOf<[]>();
-    expect(forever).returns.toEqualTypeOf<PromiseLike<never>>();
+    expect(forever).returns.toEqualTypeOf<Yieldable<never>>();
 
     // @ts-expect-error
     forever('nope');

--- a/tests/unit/cancelable-promise-helpers-test.js
+++ b/tests/unit/cancelable-promise-helpers-test.js
@@ -624,8 +624,8 @@ module('Unit: cancelable promises test helpers', function() {
 
     let wrapCancelation = (yieldable, shouldBeCalled = true) => {
       let originalOnYield = yieldable.onYield.bind(yieldable);
-      yieldable.onYield = () => {
-        let disposer = originalOnYield();
+      yieldable.onYield = (...args) => {
+        let disposer = originalOnYield(...args);
         disposer();
         assert.ok(shouldBeCalled);
       };

--- a/tests/unit/cancelable-promise-helpers-test.js
+++ b/tests/unit/cancelable-promise-helpers-test.js
@@ -623,9 +623,10 @@ module('Unit: cancelable promises test helpers', function() {
     assert.expect(6);
 
     let wrapCancelation = (yieldable, shouldBeCalled = true) => {
-      let originalCancel = yieldable.__ec_cancel__.bind(yieldable);
-      yieldable.__ec_cancel__ = () => {
-        originalCancel();
+      let originalOnYield = yieldable.onYield.bind(yieldable);
+      yieldable.onYield = () => {
+        let disposer = originalOnYield();
+        disposer();
         assert.ok(shouldBeCalled);
       };
     }


### PR DESCRIPTION
[Rendered](https://github.com/machty/ember-concurrency/blob/mf-public_yieldable/rfcs/0000-yieldables.md)

Implementation is included as well, which shows refactor of built-in Yieldables to use the new API. Refactoring (or similar) will probably stand, regardless of whether to promote to public API, as calling `taskInstance.proceed` with various magic values in a bunch of places is error prone.