### PR TITLE
Remove runloop binding for perform helper

### DIFF
--- a/addon/-private/ember-environment.js
+++ b/addon/-private/ember-environment.js
@@ -2,7 +2,7 @@ import Ember from 'ember';
 import { defer } from 'rsvp';
 import { Environment } from "./external/environment";
 import { assert } from '@ember/debug';
-import { join, schedule, later } from '@ember/runloop';
+import { join, next, once } from '@ember/runloop';
 
 export class EmberEnvironment extends Environment {
   assert(...args) {
@@ -10,17 +10,17 @@ export class EmberEnvironment extends Environment {
   }
 
   async(callback) {
-    join(() => schedule('actions', null, callback));
+    join(() => once(null, callback));
   }
 
   reportUncaughtRejection(error) {
-    later(function() {
+    next(null, function() {
       if (Ember.onerror) {
         Ember.onerror(error);
       } else {
         throw error;
       }
-    }, 1);
+    });
   }
 
   defer() {

--- a/addon/-private/external/task-instance/executor.js
+++ b/addon/-private/external/task-instance/executor.js
@@ -6,13 +6,13 @@ import {
   YIELDABLE_THROW,
   YIELDABLE_RETURN,
   YIELDABLE_CANCEL,
-  cancelableSymbol
-} from '../yieldables';
+  cancelableSymbol,
+} from "../yieldables";
 
 import {
   COMPLETION_SUCCESS,
   COMPLETION_ERROR,
-  COMPLETION_CANCEL
+  COMPLETION_CANCEL,
 } from "./completion-states";
 import {
   CancelRequest,
@@ -20,7 +20,7 @@ import {
   CANCEL_KIND_LIFESPAN_END,
   CANCEL_KIND_PARENT_CANCEL,
   didCancel,
-  TASK_CANCELATION_NAME
+  TASK_CANCELATION_NAME,
 } from "./cancelation";
 
 export const PERFORM_TYPE_DEFAULT = "PERFORM_TYPE_DEFAULT";
@@ -191,10 +191,10 @@ export class TaskInstanceExecutor {
   handleYieldedUnknownThenable(thenable) {
     let resumeIndex = this.index;
     thenable.then(
-      value => {
+      (value) => {
         this.proceedChecked(resumeIndex, YIELDABLE_CONTINUE, value);
       },
-      error => {
+      (error) => {
         this.proceedChecked(resumeIndex, YIELDABLE_THROW, error);
       }
     );
@@ -270,7 +270,7 @@ export class TaskInstanceExecutor {
       return;
     }
     this.disposers = [];
-    disposers.forEach(disposer => disposer());
+    disposers.forEach((disposer) => disposer());
   }
 
   /**
@@ -320,7 +320,7 @@ export class TaskInstanceExecutor {
   }
 
   runFinalizeCallbacks() {
-    this.finalizeCallbacks.forEach(cb => cb());
+    this.finalizeCallbacks.forEach((cb) => cb());
     this.finalizeCallbacks = [];
     this.maybeResolveDefer();
     this.maybeThrowUnhandledTaskErrorLater();
@@ -394,7 +394,7 @@ export class TaskInstanceExecutor {
       isCanceled: true,
       completionState: COMPLETION_CANCEL,
       error,
-      cancelReason
+      cancelReason,
     });
 
     this.cancelRequest.finalize();
@@ -464,11 +464,7 @@ export class TaskInstanceExecutor {
     this.onFinalize(() => {
       let completionState = this.state.completionState;
       if (completionState === COMPLETION_SUCCESS) {
-        parent.proceed(
-          resumeIndex,
-          YIELDABLE_CONTINUE,
-          this.state.value
-        );
+        parent.proceed(resumeIndex, YIELDABLE_CONTINUE, this.state.value);
       } else if (completionState === COMPLETION_ERROR) {
         parent.proceed(resumeIndex, YIELDABLE_THROW, this.state.error);
       } else if (completionState === COMPLETION_CANCEL) {

--- a/addon/-private/helpers.js
+++ b/addon/-private/helpers.js
@@ -1,12 +1,11 @@
 import { get } from '@ember/object';
 import { assert } from '@ember/debug';
-import { bind } from '@ember/runloop';
 
 export function taskHelperClosure(helperName, taskMethod, _args, hash) {
   let task = _args[0];
   let outerArgs = _args.slice(1);
 
-  return bind(null, function(...innerArgs) {
+  return function(...innerArgs) {
     if (!task || typeof task[taskMethod] !== 'function') {
       assert(`The first argument passed to the \`${helperName}\` helper should be a Task object (without quotes); you passed ${task}`, false);
       return;
@@ -18,5 +17,5 @@ export function taskHelperClosure(helperName, taskMethod, _args, hash) {
     }
 
     return task[taskMethod](...outerArgs, ...innerArgs);
-  });
+  };
 }

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -25,6 +25,10 @@ module.exports = function(defaults) {
 
     babel: babelOptions,
 
+    autoImport: {
+      forbidEval: true,
+    },
+
     'ember-cli-babel': {
       includePolyfill: process.env.EMBER_ENV === 'production'
     },

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "ember-resolver": "^8.0.2",
     "ember-router-service-polyfill": "^1.0.3",
     "ember-sinon": "^2.1.0",
-    "ember-source": "~3.22.0",
+    "ember-source": "~3.25.0",
     "ember-source-channel-url": "^3.0.0",
     "ember-template-lint": "^2.14.0",
     "ember-try": "^1.4.0",

--- a/tests/dummy/app/helpers/swallow-error.js
+++ b/tests/dummy/app/helpers/swallow-error.js
@@ -1,0 +1,36 @@
+import { helper } from "@ember/component/helper";
+
+/**
+ * This helper is meant to be wrapped around another action that might throw
+ * an error that we want to suppress.
+ *
+ * While this pattern should be used sparingly, as errors should generally not be ignores, it
+ * is sometimes appropriate to follow do this when working with an Ember Concurrency task that uses
+ * the `.error` derrived state to directly render the error from a Task. In these cases, we rarely
+ * want the error to bubble up to the application itself, as we're already handling the error case.
+ *
+ *   ```hbs
+ *   <button {{on 'click' (swallow-error (perform this.someTaskThatMightThrow))}}>
+ *     Click Me
+ *   </button>
+ *   ```
+ */
+export function swallowError([fn]) {
+  return function callAndSwallowError(...args) {
+    try {
+      const response = fn(...args);
+
+      if (response.catch) {
+        return response.catch(function () {
+          // Swallow async error
+        });
+      }
+
+      return response;
+    } catch (e) {
+      // Swallow synchronous error
+    }
+  };
+}
+
+export default helper(swallowError);

--- a/tests/integration/helpers/perform-test.js
+++ b/tests/integration/helpers/perform-test.js
@@ -1,0 +1,32 @@
+import { module, test } from "qunit";
+import { setupRenderingTest } from "ember-qunit";
+import { click, render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import Component from "@ember/component";
+import { task } from "ember-concurrency";
+
+module("Integration | helpers | perform", function (hooks) {
+  setupRenderingTest(hooks);
+
+  test("can wrap (perform) calls to instrument TaskInstance", async function (assert) {
+    assert.expect(1);
+
+    this.owner.register('component:test-swallow-error', Component.extend({
+      errorGeneratingTask: task(function * () {
+        throw new Error("You should not see me!");
+      }),
+    }));
+
+    this.owner.register('template:components/test-swallow-error', hbs`
+      <button {{on 'click' (swallow-error (perform this.errorGeneratingTask))}}>
+        I create an error!
+      </button>
+    `);
+
+    await render(hbs`<TestSwallowError />`);
+
+    await click("button");
+
+    assert.ok(true);
+  });
+});

--- a/tests/unit/error-handling-test.js
+++ b/tests/unit/error-handling-test.js
@@ -31,6 +31,28 @@ module('Unit: task error handling', function() {
     });
   });
 
+  test('synchronous errors can be caught asynchronously', function(assert) {
+    assert.expect(1);
+
+    let Obj = EmberObject.extend({
+      throwError: task(function * () {
+        throw new Error('This error should be caught')
+      }),
+    });
+
+    run(()=> {
+      let obj = Obj.create();
+
+      obj.throwError.perform().catch(e => {
+        assert.equal(
+          e.message,
+          'This error should be caught',
+          'The thrown error was caught'
+        );
+      });
+    });
+  });
+
   test("parent task canceled by restartable policy: no errors", function(assert) {
     assert.expect(1);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1248,6 +1248,13 @@
   resolved "https://registry.yarnpkg.com/@glimmer/validator/-/validator-0.44.0.tgz#03d127097dc9cb23052cdb7fcae59d0a9dca53e1"
   integrity sha512-i01plR0EgFVz69GDrEuFgq1NheIjZcyTy3c7q+w7d096ddPVeVcRzU3LKaqCfovvLJ+6lJx40j45ecycASUUyw==
 
+"@glimmer/vm-babel-plugins@0.74.2":
+  version "0.74.2"
+  resolved "https://registry.yarnpkg.com/@glimmer/vm-babel-plugins/-/vm-babel-plugins-0.74.2.tgz#479774d5885201538245f4cba76cabd4b0dee3a5"
+  integrity sha512-DLIKzim7Fg3o54EPgz/wsEiLOUcg24P4WJ9AAv4xsXfBmFndkEDzq1oJ3SPhB167Vp1m+GKOlfKzFm9mxX5rdA==
+  dependencies:
+    babel-plugin-debug-macros "^0.3.4"
+
 "@glimmer/vm@^0.42.2":
   version "0.42.2"
   resolved "https://registry.yarnpkg.com/@glimmer/vm/-/vm-0.42.2.tgz#492a4f05eac587c3a37371b3c62593f20bef553d"
@@ -2638,10 +2645,10 @@ babel-plugin-debug-macros@^0.2.0, babel-plugin-debug-macros@^0.2.0-beta.6:
   dependencies:
     semver "^5.3.0"
 
-babel-plugin-debug-macros@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.3.tgz#29c3449d663f61c7385f5b8c72d8015b069a5cb7"
-  integrity sha512-E+NI8TKpxJDBbVkdWkwHrKgJi696mnRL8XYrOPYw82veNHPDORM9WIQifl6TpIo8PNy2tU2skPqbfkmHXrHKQA==
+babel-plugin-debug-macros@^0.3.3, babel-plugin-debug-macros@^0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-debug-macros/-/babel-plugin-debug-macros-0.3.4.tgz#22961d0cb851a80654cece807a8b4b73d85c6075"
+  integrity sha512-wfel/vb3pXfwIDZUrkoDrn5FHmlWI96PCJ3UCDv2a86poJ3EQrnArNW5KfHSVJ9IOgxHbo748cQt7sDU+0KCEw==
   dependencies:
     semver "^5.3.0"
 
@@ -2666,7 +2673,14 @@ babel-plugin-ember-modules-api-polyfill@^2.6.0:
   dependencies:
     ember-rfc176-data "^0.3.13"
 
-babel-plugin-ember-modules-api-polyfill@^3.2.1, babel-plugin-ember-modules-api-polyfill@^3.4.0:
+babel-plugin-ember-modules-api-polyfill@^3.2.1:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.4.0.tgz#3f5e0457e135f8a29b3a8b6910806bb5b524649e"
+  integrity sha512-nVu/LqbZBAup1zLij6xGvQwVLWVk4XYu2fl4vIOUR3S6ukdonMLhKAb0d4QXSzH30Pd7OczVTlPffWbiwahdJw==
+  dependencies:
+    ember-rfc176-data "^0.3.16"
+
+babel-plugin-ember-modules-api-polyfill@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-3.4.0.tgz#3f5e0457e135f8a29b3a8b6910806bb5b524649e"
   integrity sha512-nVu/LqbZBAup1zLij6xGvQwVLWVk4XYu2fl4vIOUR3S6ukdonMLhKAb0d4QXSzH30Pd7OczVTlPffWbiwahdJw==
@@ -5595,7 +5609,39 @@ ember-cli-babel@^6.11.0, ember-cli-babel@^6.12.0, ember-cli-babel@^6.16.0, ember
     ember-cli-version-checker "^2.1.2"
     semver "^5.5.0"
 
-ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.0, ember-cli-babel@^7.23.1, ember-cli-babel@^7.7.3:
+ember-cli-babel@^7.0.0, ember-cli-babel@^7.1.0, ember-cli-babel@^7.1.3, ember-cli-babel@^7.10.0, ember-cli-babel@^7.11.0, ember-cli-babel@^7.11.1, ember-cli-babel@^7.13.2, ember-cli-babel@^7.19.0, ember-cli-babel@^7.21.0, ember-cli-babel@^7.22.1, ember-cli-babel@^7.23.1, ember-cli-babel@^7.7.3:
+  version "7.23.1"
+  resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.23.1.tgz#d1517228ede08a5d4b045c78a7429728e956b30b"
+  integrity sha512-qYggmt3hRs6QJ6cRkww3ahMpyP8IEV2KFrIRO/Z6hu9MkE/8Y28Xd5NjQl6fPV3oLoG0vwuHzhNe3Jr7Wec8zw==
+  dependencies:
+    "@babel/core" "^7.12.0"
+    "@babel/helper-compilation-targets" "^7.12.0"
+    "@babel/plugin-proposal-class-properties" "^7.10.4"
+    "@babel/plugin-proposal-decorators" "^7.10.5"
+    "@babel/plugin-transform-modules-amd" "^7.10.5"
+    "@babel/plugin-transform-runtime" "^7.12.0"
+    "@babel/plugin-transform-typescript" "^7.12.0"
+    "@babel/polyfill" "^7.11.5"
+    "@babel/preset-env" "^7.12.0"
+    "@babel/runtime" "^7.12.0"
+    amd-name-resolver "^1.2.1"
+    babel-plugin-debug-macros "^0.3.3"
+    babel-plugin-ember-data-packages-polyfill "^0.1.2"
+    babel-plugin-ember-modules-api-polyfill "^3.2.1"
+    babel-plugin-module-resolver "^3.1.1"
+    broccoli-babel-transpiler "^7.8.0"
+    broccoli-debug "^0.6.4"
+    broccoli-funnel "^2.0.1"
+    broccoli-source "^1.1.0"
+    clone "^2.1.2"
+    ember-cli-babel-plugin-helpers "^1.1.1"
+    ember-cli-version-checker "^4.1.0"
+    ensure-posix-path "^1.0.2"
+    fixturify-project "^1.10.0"
+    rimraf "^3.0.1"
+    semver "^5.5.0"
+
+ember-cli-babel@^7.23.0:
   version "7.23.1"
   resolved "https://registry.yarnpkg.com/ember-cli-babel/-/ember-cli-babel-7.23.1.tgz#d1517228ede08a5d4b045c78a7429728e956b30b"
   integrity sha512-qYggmt3hRs6QJ6cRkww3ahMpyP8IEV2KFrIRO/Z6hu9MkE/8Y28Xd5NjQl6fPV3oLoG0vwuHzhNe3Jr7Wec8zw==
@@ -6274,15 +6320,16 @@ ember-source-channel-url@^3.0.0:
   dependencies:
     node-fetch "^2.6.0"
 
-ember-source@~3.22.0:
-  version "3.22.0"
-  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.22.0.tgz#aa09db2cc8e4f78de4bf9a12ce9ff499d416adc2"
-  integrity sha512-6F/fWA5et4AMFXm+siCIhpM2XrO8Emwqln71qK67JyUhvD3MJJtvwtBoKq7bzK9I/86LLw13JYm4o6T3d2gXBw==
+ember-source@~3.25.0:
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/ember-source/-/ember-source-3.25.1.tgz#7621fe7d471d08045b95c79fc760c3ca44efce4f"
+  integrity sha512-WCQV3FqbXRkYAwrwLZ6QcHZcTjT9ESa9H8Il+5H0QmDxLPiFnaj/UW4YLgZZ64X9PBT9WCUzLeLcccIFoFFm7w==
   dependencies:
     "@babel/helper-module-imports" "^7.8.3"
     "@babel/plugin-transform-block-scoping" "^7.8.3"
     "@babel/plugin-transform-object-assign" "^7.8.3"
     "@ember/edition-utils" "^1.2.0"
+    "@glimmer/vm-babel-plugins" "0.74.2"
     babel-plugin-debug-macros "^0.3.3"
     babel-plugin-filter-imports "^4.0.0"
     broccoli-concat "^4.2.4"
@@ -6290,7 +6337,7 @@ ember-source@~3.22.0:
     broccoli-funnel "^2.0.2"
     broccoli-merge-trees "^4.2.0"
     chalk "^4.0.0"
-    ember-cli-babel "^7.19.0"
+    ember-cli-babel "^7.23.0"
     ember-cli-get-component-path-option "^1.0.0"
     ember-cli-is-package-missing "^1.0.0"
     ember-cli-normalize-entity-name "^1.0.0"


### PR DESCRIPTION
Wrapping `perform` in a full runloop means that a synchronous task throw will be
reported within that same invocation, before another helper is able to wrap and
instrument the task instance. Since it's already run, it's too late to do things
like attaching catch handlers. We do not need this runloop binding anymore, since
there's no auto-run assertion with the versions supported by ember-concurrency
2.x.

Fixes #409 