### PR TITLE
Avoid applying states out of order

### DIFF
--- a/addon/-private/external/scheduler/refresh.js
+++ b/addon/-private/external/scheduler/refresh.js
@@ -2,7 +2,9 @@ import {
   TYPE_STARTED,
   TYPE_QUEUED,
   TYPE_CANCELLED
-} from "./policies/execution-states"
+} from "./policies/execution-states";
+
+let LAST_APPLIED_TAG = 0;
 
 class Refresh {
   constructor(schedulerPolicy, stateTracker, taskInstances) {
@@ -83,6 +85,10 @@ class Refresh {
       return;
     }
 
+    if (state.tag < LAST_APPLIED_TAG) {
+      return;
+    }
+
     let props = Object.assign({
       numRunning: state.numRunning,
       numQueued: state.numQueued,
@@ -90,6 +96,8 @@ class Refresh {
     }, state.attrs);
 
     taskable.onState(props, taskable);
+
+    LAST_APPLIED_TAG = state.tag;
   }
 }
 

--- a/addon/-private/external/scheduler/state-tracker/state-tracker.js
+++ b/addon/-private/external/scheduler/state-tracker/state-tracker.js
@@ -1,15 +1,18 @@
 import RefreshState from "./state";
 
+let CURRENT_TAG = 0;
+
 class StateTracker {
   constructor() {
-    this.states = {};
+    this.states = new Map();
   }
 
   stateFor(taskable) {
     let guid = taskable.guid;
-    let taskState = this.states[guid];
+    let taskState = this.states.get(guid);
     if (!taskState) {
-      taskState = this.states[guid] = new RefreshState(taskable);
+      taskState = new RefreshState(taskable, ++CURRENT_TAG);
+      this.states.set(guid, taskState);
     }
     return taskState;
   }
@@ -35,7 +38,7 @@ class StateTracker {
   }
 
   forEachState(callback) {
-    Object.keys(this.states).forEach(k => callback(this.states[k]));
+    this.states.forEach(state => callback(state));
   }
 }
 

--- a/addon/-private/external/scheduler/state-tracker/state.js
+++ b/addon/-private/external/scheduler/state-tracker/state.js
@@ -5,13 +5,14 @@ import {
 } from "../../task-instance/completion-states";
 
 class RefreshState {
-  constructor(taskable) {
+  constructor(taskable, tag) {
     this.taskable = taskable;
     this.group = taskable.group;
     this.numRunning = 0;
     this.numQueued = 0;
     this.numPerformedInc = 0;
     this.attrs = {};
+    this.tag = tag;
   }
 
   onCompletion(taskInstance) {


### PR DESCRIPTION
Covered by the included test case based on #422.

Given a bounded scheduler policy that drops running
task instances, if there's an immediate return in
via a later perform call, the state update from the earlier
task instance may get applied later than the task instance
with the immediate return.

Applied a similar approach that Glimmer uses, which is an
incrementing tag, by which we will track which state updates
are still valid. Anything after the last applied tag will be valid
and state updates from before will be ignored.