### PR TITLE
Cast Yieldables to promises when using cancelable promise helpers

### DIFF
--- a/tests/acceptance/helpers-test.js
+++ b/tests/acceptance/helpers-test.js
@@ -1,14 +1,32 @@
 import { click, visit, currentURL } from '@ember/test-helpers';
 import Ember from 'ember';
+import { gte } from 'ember-compatibility-helpers';
 import { setupApplicationTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
-let originalAssert = Ember.assert;
+function getDebugFunction(type) {
+  if (gte('3.26.0')) {
+    return Ember.__loader.require("@ember/debug").getDebugFunction(type);
+  } else {
+    return Ember[type];
+  }
+}
+
+function setDebugFunction(type, fn) {
+  if (gte('3.26.0')) {
+    Ember.__loader.require("@ember/debug").setDebugFunction(type, fn);
+  } else {
+    Ember[type] = fn;
+  }
+}
+
+const originalAssert = getDebugFunction('assert');
+
 module('Acceptance | helpers', function(hooks) {
   setupApplicationTest(hooks)
 
   hooks.afterEach(function() {
-    Ember.assert = originalAssert;
+    setDebugFunction('assert', originalAssert);
   });
 
   test('perform and cancel-all', async function(assert) {
@@ -29,24 +47,23 @@ module('Acceptance | helpers', function(hooks) {
   });
 
   test('passing non-Tasks to (perform) helper only errors when invoked', async function(assert) {
-    assert.expect(4);
-
-    let assertArgs = [];
-    Ember.assert = (message, flag) => {
-      if (!flag) {
-        assertArgs.push(message);
-      }
-    };
+    assert.expect(2);
 
     await visit('/helpers-test');
-    assert.deepEqual(assertArgs, []);
+
+    setDebugFunction('assert', function (desc, test) {
+      if (!test) {
+        assert.deepEqual(desc, "The first argument passed to the `perform` helper should be a Task object (without quotes); you passed null");
+      }
+    });
+
     await click('.maybe-null-task');
-    assert.deepEqual(assertArgs, [ "The first argument passed to the `perform` helper should be a Task object (without quotes); you passed null" ]);
-    // eslint-disable-next-line require-atomic-updates
-    assertArgs.length = 0;
+
+    setDebugFunction('assert', originalAssert);
+
     await click('.setup-task');
     await click('.maybe-null-task');
-    assert.deepEqual(assertArgs, []);
+
     assert.dom('.task-status').hasText('someTask');
   });
 });

--- a/tests/dummy/app/helpers/color.js
+++ b/tests/dummy/app/helpers/color.js
@@ -1,9 +1,8 @@
 import { helper } from '@ember/component/helper';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 export function colorString([color]/*, hash*/) {
   return new htmlSafe(`color: ${color};`);
 }
 
 export default helper(colorString);
-

--- a/tests/dummy/app/helpers/progress-style.js
+++ b/tests/dummy/app/helpers/progress-style.js
@@ -1,5 +1,5 @@
 import { helper } from '@ember/component/helper';
-import { htmlSafe } from '@ember/string';
+import { htmlSafe } from '@ember/template';
 
 export function progressStyleHelper([percent, id, colors]/*, hash*/) {
   let color = colors[id % colors.length];
@@ -7,4 +7,3 @@ export function progressStyleHelper([percent, id, colors]/*, hash*/) {
 }
 
 export default helper(progressStyleHelper);
-


### PR DESCRIPTION
Bug found in #413

Yieldables themselves can be triggered multiple times and return a different promise everytime they're casted, which Promise/RSVP.all, allSettled, race, etc. will do internally, but prevents collecting the disposer to use for cancelation. This effectively neutralizes cancellation, which is not what we want, so we need to cast it before handing it off to the Promise/RSVP implementation.