### PR TITLE
Extract generic TaskFactory base class

### DIFF
--- a/addon/-private/external/scheduler/scheduler.js
+++ b/addon/-private/external/scheduler/scheduler.js
@@ -41,8 +41,9 @@ class Scheduler {
     this.refresh();
   }
 
-  // override
-  scheduleRefresh() {}
+  scheduleRefresh() {
+    Promise.resolve().then(() => this.refresh());
+  }
 
   refresh() {
     let stateTracker = this.stateTrackingEnabled

--- a/addon/-private/external/task-factory.js
+++ b/addon/-private/external/task-factory.js
@@ -1,11 +1,11 @@
 import Scheduler from './scheduler/scheduler';
-import UnboundedSchedulerPolicy from "./scheduler/policies/unbounded-policy";
-import EnqueueSchedulerPolicy from "./scheduler/policies/enqueued-policy";
-import DropSchedulerPolicy from "./scheduler/policies/drop-policy";
-import KeepLatestSchedulerPolicy from "./scheduler/policies/keep-latest-policy";
-import RestartableSchedulerPolicy from "./scheduler/policies/restartable-policy";
-import { Task } from "./task/task";
-import { TaskGroup } from "./task/task-group";
+import UnboundedSchedulerPolicy from './scheduler/policies/unbounded-policy';
+import EnqueueSchedulerPolicy from './scheduler/policies/enqueued-policy';
+import DropSchedulerPolicy from './scheduler/policies/drop-policy';
+import KeepLatestSchedulerPolicy from './scheduler/policies/keep-latest-policy';
+import RestartableSchedulerPolicy from './scheduler/policies/restartable-policy';
+import { Task } from './task/task';
+import { TaskGroup } from './task/task-group';
 
 function assertModifiersNotMixedWithGroup(obj) {
   if (obj._hasSetConcurrencyConstraint && obj._taskGroupPath) {
@@ -24,18 +24,20 @@ function assertUnsetBufferPolicy(obj) {
 }
 
 const MODIFIER_REGISTRY = {
-  enqueue: (factory, value) => (
-    value && factory.setBufferPolicy(EnqueueSchedulerPolicy)
-  ),
+  enqueue: (factory, value) =>
+    value && factory.setBufferPolicy(EnqueueSchedulerPolicy),
   evented: (factory, value) => value && factory.setEvented(value),
   debug: (factory, value) => value && factory.setDebug(value),
-  drop: (factory, value) => value && factory.setBufferPolicy(DropSchedulerPolicy),
+  drop: (factory, value) =>
+    value && factory.setBufferPolicy(DropSchedulerPolicy),
   group: (factory, groupName) => factory.setGroup(groupName),
-  keepLatest: (factory, value) => value && factory.setBufferPolicy(KeepLatestSchedulerPolicy),
+  keepLatest: (factory, value) =>
+    value && factory.setBufferPolicy(KeepLatestSchedulerPolicy),
   maxConcurrency: (factory, maxConcurrency) =>
     factory.setMaxConcurrency(maxConcurrency),
   onState: (factory, onStateCallback) => factory.setOnState(onStateCallback),
-  restartable: (factory, value) => value && factory.setBufferPolicy(RestartableSchedulerPolicy),
+  restartable: (factory, value) =>
+    value && factory.setBufferPolicy(RestartableSchedulerPolicy),
 };
 
 export function defineModifier(name, callback) {
@@ -60,7 +62,7 @@ export class TaskFactory {
   _schedulerPolicyClass = UnboundedSchedulerPolicy;
   _taskGroupPath = null;
 
-  constructor(name = "<unknown>", taskDefinition = null, options = {}) {
+  constructor(name = '<unknown>', taskDefinition = null, options = {}) {
     this.name = name;
     this.taskDefinition = taskDefinition;
 
@@ -73,8 +75,7 @@ export class TaskFactory {
     return new Task(
       Object.assign(
         {
-          generatorFactory: (args) =>
-            this.taskDefinition.apply(context, args),
+          generatorFactory: (args) => this.taskDefinition.apply(context, args),
         },
         options
       )
@@ -104,7 +105,9 @@ export class TaskFactory {
     if (this._taskGroupPath) {
       group = context[this._taskGroupPath];
       if (!(group instanceof TaskGroup)) {
-        throw new Error(`Expected group '${this._taskGroupPath}' to be defined but was not found.`);
+        throw new Error(
+          `Expected group '${this._taskGroupPath}' to be defined but was not found.`
+        );
       }
 
       scheduler = group.scheduler;

--- a/addon/-private/external/task-factory.js
+++ b/addon/-private/external/task-factory.js
@@ -1,0 +1,184 @@
+import Scheduler from './scheduler/scheduler';
+import UnboundedSchedulerPolicy from "./scheduler/policies/unbounded-policy";
+import EnqueueSchedulerPolicy from "./scheduler/policies/enqueued-policy";
+import DropSchedulerPolicy from "./scheduler/policies/drop-policy";
+import KeepLatestSchedulerPolicy from "./scheduler/policies/keep-latest-policy";
+import RestartableSchedulerPolicy from "./scheduler/policies/restartable-policy";
+import { Task } from "./task/task";
+import { TaskGroup } from "./task/task-group";
+
+function assertModifiersNotMixedWithGroup(obj) {
+  if (obj._hasSetConcurrencyConstraint && obj._taskGroupPath) {
+    throw new Error(
+      `Cannot use both 'group' and other concurrency-constraining task modifiers (e.g. 'drop', 'enqueue', 'restartable')`
+    );
+  }
+}
+
+function assertUnsetBufferPolicy(obj) {
+  if (obj._hasSetBufferPolicy) {
+    throw new Error(
+      `Cannot set multiple buffer policies on a task or task group. ${obj._schedulerPolicyClass} has already been set for task or task group '${obj.name}'`
+    );
+  }
+}
+
+const MODIFIER_REGISTRY = {
+  enqueue: (factory, value) => (
+    value && factory.setBufferPolicy(EnqueueSchedulerPolicy)
+  ),
+  evented: (factory, value) => value && factory.setEvented(value),
+  debug: (factory, value) => value && factory.setDebug(value),
+  drop: (factory, value) => value && factory.setBufferPolicy(DropSchedulerPolicy),
+  group: (factory, groupName) => factory.setGroup(groupName),
+  keepLatest: (factory, value) => value && factory.setBufferPolicy(KeepLatestSchedulerPolicy),
+  maxConcurrency: (factory, maxConcurrency) =>
+    factory.setMaxConcurrency(maxConcurrency),
+  onState: (factory, onStateCallback) => factory.setOnState(onStateCallback),
+  restartable: (factory, value) => value && factory.setBufferPolicy(RestartableSchedulerPolicy),
+};
+
+export function defineModifier(name, callback) {
+  if (MODIFIER_REGISTRY[name]) {
+    throw new Error(
+      `A modifier with the name '${name}' has already been defined.`
+    );
+  }
+
+  MODIFIER_REGISTRY[name] = callback;
+}
+
+export class TaskFactory {
+  _cancelEventNames = [];
+  _debug = null;
+  _eventNames = [];
+  _hasSetConcurrencyConstraint = false;
+  _hasSetBufferPolicy = false;
+  _hasEnabledEvents = false;
+  _maxConcurrency = null;
+  _onStateCallback = (state, taskable) => taskable.setState(state);
+  _schedulerPolicyClass = UnboundedSchedulerPolicy;
+  _taskGroupPath = null;
+
+  constructor(name = "<unknown>", taskDefinition = null, options = {}) {
+    this.name = name;
+    this.taskDefinition = taskDefinition;
+
+    this._processModifierOptions(options);
+  }
+
+  createTask(context) {
+    let options = this.getTaskOptions(context);
+
+    return new Task(
+      Object.assign(
+        {
+          generatorFactory: (args) =>
+            this.taskDefinition.apply(context, args),
+        },
+        options
+      )
+    );
+  }
+
+  createTaskGroup(context) {
+    let options = this.getTaskOptions(context);
+
+    return new TaskGroup(options);
+  }
+
+  getModifier(name) {
+    if (MODIFIER_REGISTRY[name]) {
+      return MODIFIER_REGISTRY[name].bind(null, this);
+    }
+  }
+
+  getScheduler(schedulerPolicy, onStateCallback) {
+    return new Scheduler(schedulerPolicy, onStateCallback);
+  }
+
+  getTaskOptions(context) {
+    let group, scheduler;
+    let onStateCallback = this._onStateCallback;
+
+    if (this._taskGroupPath) {
+      group = context[this._taskGroupPath];
+      if (!(group instanceof TaskGroup)) {
+        throw new Error(`Expected group '${this._taskGroupPath}' to be defined but was not found.`);
+      }
+
+      scheduler = group.scheduler;
+    } else {
+      let schedulerPolicy = new this._schedulerPolicyClass(
+        this._maxConcurrency
+      );
+      scheduler = this.getScheduler(schedulerPolicy, onStateCallback);
+    }
+
+    return {
+      context,
+      debug: this._debug,
+      name: this.name,
+      group,
+      scheduler,
+      hasEnabledEvents: this._hasEnabledEvents,
+      onStateCallback,
+    };
+  }
+
+  setBufferPolicy(policy) {
+    assertUnsetBufferPolicy(this);
+    this._hasSetBufferPolicy = true;
+    this._hasSetConcurrencyConstraint = true;
+    this._schedulerPolicyClass = policy;
+    assertModifiersNotMixedWithGroup(this);
+
+    return this;
+  }
+
+  setDebug(debug) {
+    this._debug = debug;
+    return this;
+  }
+
+  setEvented(evented) {
+    this._hasEnabledEvents = evented;
+    return this;
+  }
+
+  setMaxConcurrency(maxConcurrency) {
+    this._hasSetConcurrencyConstraint = true;
+    this._maxConcurrency = maxConcurrency;
+    return this;
+  }
+
+  setGroup(group) {
+    this._taskGroupPath = group;
+    return this;
+  }
+
+  setName(name) {
+    this.name = name;
+    return this;
+  }
+
+  setOnState(onStateCallback) {
+    this._onStateCallback = onStateCallback;
+    return this;
+  }
+
+  setTaskDefinition(taskDefinition) {
+    this.taskDefinition = taskDefinition;
+    return this;
+  }
+
+  _processModifierOptions(options) {
+    for (let key of Object.keys(options)) {
+      let value = options[key];
+      let modifier = this.getModifier(key);
+      if (modifier) {
+        modifier(value);
+      }
+    }
+  }
+}

--- a/addon/-private/external/task/task.js
+++ b/addon/-private/external/task/task.js
@@ -20,6 +20,7 @@ class TaskLinkProxy {
 export class Task extends Taskable {
   constructor(options) {
     super(options);
+    this.generatorFactory = options.generatorFactory;
     this.perform = this._perform.bind(this);
   }
 

--- a/addon/-private/external/task/taskable.js
+++ b/addon/-private/external/task/taskable.js
@@ -11,8 +11,13 @@ function makeGuid() {
 
 export class Taskable {
   constructor(options) {
-    this.options = options;
-    Object.assign(this, options);
+    this.context = options.context;
+    this.debug = options.debug || false;
+    this.group = options.group;
+    this.hasEnabledEvents = options.hasEnabledEvents;
+    this.name = options.name;
+    this.onStateCallback = options.onStateCallback;
+    this.scheduler = options.scheduler;
 
     this.guid = makeGuid();
     this.guids = {};

--- a/addon/-private/task-decorators.js
+++ b/addon/-private/task-decorators.js
@@ -1,5 +1,5 @@
 import { computed, get } from '@ember/object';
-import { TaskFactory, TaskGroupFactory } from './task-factory';
+import { TaskFactory } from './task-factory';
 import { USE_TRACKED } from './utils';
 
 function taskFromPropertyDescriptor(target, key, descriptor, params = []) {
@@ -38,7 +38,7 @@ function taskFromPropertyDescriptor(target, key, descriptor, params = []) {
 function taskGroupPropertyDescriptor(target, key, _descriptor, params = []) {
   let taskGroups = new WeakMap();
   let options = params[0] || {};
-  let factory = new TaskGroupFactory(key, null, options);
+  let factory = new TaskFactory(key, null, options);
 
   return {
     get() {

--- a/addon/-private/task-factory.js
+++ b/addon/-private/task-factory.js
@@ -1,34 +1,19 @@
-import UnboundedSchedulerPolicy from './external/scheduler/policies/unbounded-policy';
-import EnqueueSchedulerPolicy from './external/scheduler/policies/enqueued-policy';
-import DropSchedulerPolicy from './external/scheduler/policies/drop-policy';
-import KeepLatestSchedulerPolicy from './external/scheduler/policies/keep-latest-policy';
-import RestartableSchedulerPolicy from './external/scheduler/policies/restartable-policy';
-
 import { assert } from '@ember/debug';
 import { get } from '@ember/object';
 import { addListener } from '@ember/object/events';
 import { addObserver } from '@ember/object/observers';
 import { scheduleOnce } from '@ember/runloop';
+import {
+  defineModifier,
+  TaskFactory as BaseTaskFactory,
+} from './external/task-factory';
+
 import { Task, EncapsulatedTask } from './task';
 import { TaskProperty } from './task-properties';
 import { TaskGroup } from './task-group';
 import EmberScheduler from './scheduler/ember-scheduler';
 
 let handlerCounter = 0;
-
-function assertModifiersNotMixedWithGroup(obj) {
-  assert(
-    `ember-concurrency does not currently support using both 'group' with other task modifiers (e.g. 'drop', 'enqueue', 'restartable')`,
-    !obj._hasUsedModifier || !obj._taskGroupPath
-  );
-}
-
-function assertUnsetBufferPolicy(obj) {
-  assert(
-    `Cannot set multiple buffer policies on a task or task group. ${obj._schedulerPolicyClass} has already been set for task or task group '${obj.name}'`,
-    !obj._hasSetBufferPolicy
-  );
-}
 
 function registerOnPrototype(
   addListenerOrObserver,
@@ -38,7 +23,7 @@ function registerOnPrototype(
   taskMethod,
   once
 ) {
-  if (names) {
+  if (names && names.length > 0) {
     for (let i = 0; i < names.length; ++i) {
       let name = names[i];
 
@@ -64,51 +49,28 @@ function makeTaskCallback(taskName, method, once) {
 const ensureArray = (possibleArr) =>
   Array.isArray(possibleArr) ? possibleArr : [possibleArr];
 
-const optionRegistry = {
-  cancelOn: (factory, eventNames) =>
-    factory.addCancelEvents(...ensureArray(eventNames)),
-  enqueue: (factory) => factory.setBufferPolicy(EnqueueSchedulerPolicy),
-  evented: (factory) => factory.setEvented(true),
-  debug: (factory) => factory.setDebug(true),
-  drop: (factory) => factory.setBufferPolicy(DropSchedulerPolicy),
-  group: (factory, groupName) => factory.setGroup(groupName),
-  keepLatest: (factory) => factory.setBufferPolicy(KeepLatestSchedulerPolicy),
-  maxConcurrency: (factory, maxConcurrency) =>
-    factory.setMaxConcurrency(maxConcurrency),
-  observes: (factory, propertyPaths) =>
-    factory.addObserverKeys(...ensureArray(propertyPaths)),
-  on: (factory, eventNames) =>
-    factory.addPerformEvents(...ensureArray(eventNames)),
-  onState: (factory, onStateCallback) => factory.setOnState(onStateCallback),
-  restartable: (factory) => factory.setBufferPolicy(RestartableSchedulerPolicy),
-};
+defineModifier('cancelOn', (factory, eventNames) =>
+  factory.addCancelEvents(...ensureArray(eventNames))
+);
+defineModifier('observes', (factory, propertyPaths) =>
+  factory.addObserverKeys(...ensureArray(propertyPaths))
+);
+defineModifier('on', (factory, eventNames) =>
+  factory.addPerformEvents(...ensureArray(eventNames))
+);
 
-export class TaskFactory {
+export class TaskFactory extends BaseTaskFactory {
   _cancelEventNames = [];
-  _debug = null;
   _eventNames = [];
-  _hasUsedModifier = false;
-  _hasSetBufferPolicy = false;
-  _hasEnabledEvents = false;
-  _maxConcurrency = null;
   _observes = [];
-  _onStateCallback = (state, taskable) => taskable.setState(state);
-  _schedulerPolicyClass = UnboundedSchedulerPolicy;
-  _taskGroupPath = null;
-
-  constructor(name = '<unknown>', taskDefinition = null, options = {}) {
-    this.name = name;
-    this.taskDefinition = taskDefinition;
-
-    this._processOptions(options);
-  }
 
   createTask(context) {
     assert(
       `Cannot create task if a task definition is not provided as generator function or encapsulated task.`,
       this.taskDefinition
     );
-    let options = this._sharedTaskProperties(context);
+
+    let options = this.getTaskOptions(context);
 
     if (typeof this.taskDefinition === 'object') {
       return new EncapsulatedTask(
@@ -127,6 +89,16 @@ export class TaskFactory {
     }
   }
 
+  createTaskGroup(context) {
+    assert(
+      `A task definition is not expected for a task group.`,
+      !this.taskDefinition
+    );
+    let options = this.getTaskOptions(context);
+
+    return new TaskGroup(options);
+  }
+
   addCancelEvents(...cancelEventNames) {
     this._cancelEventNames.push(...cancelEventNames);
     return this;
@@ -142,80 +114,24 @@ export class TaskFactory {
     return this;
   }
 
-  setBufferPolicy(policy) {
-    assertUnsetBufferPolicy(this);
-    this._hasSetBufferPolicy = true;
-    this._hasUsedModifier = true;
-    this._schedulerPolicyClass = policy;
-    assertModifiersNotMixedWithGroup(this);
-
-    return this;
-  }
-
-  setDebug(debug) {
-    this._debug = debug;
-    return this;
-  }
-
-  setEvented(evented) {
-    this._hasEnabledEvents = evented;
-    return this;
-  }
-
-  setMaxConcurrency(maxConcurrency) {
-    assert(
-      `maxConcurrency must be an integer (Task '${this.name}')`,
-      Number.isInteger(maxConcurrency)
-    );
-    this._hasUsedModifier = true;
-    this._maxConcurrency = maxConcurrency;
-    assertModifiersNotMixedWithGroup(this);
-    return this;
-  }
-
-  setGroup(group) {
-    this._taskGroupPath = group;
-    assertModifiersNotMixedWithGroup(this);
-    return this;
-  }
-
-  setName(name) {
-    this.name = name;
-    return this;
-  }
-
-  setOnState(onStateCallback) {
-    this._onStateCallback = onStateCallback;
-    return this;
-  }
-
-  setTaskDefinition(taskDefinition) {
-    assert(
-      `Task definition must be a generator function or encapsulated task.`,
-      typeof taskDefinition === 'function' ||
-        (typeof taskDefinition === 'object' &&
-          typeof taskDefinition.perform === 'function')
-    );
-    this.taskDefinition = taskDefinition;
-    return this;
-  }
-
-  _processOptions(options) {
-    for (let key of Object.keys(options)) {
-      let value = options[key];
-      if (optionRegistry[key]) {
-        optionRegistry[key].call(null, this, value);
-      } else if (typeof TaskProperty.prototype[key] === 'function') {
-        // Shim for compatibility with user-defined TaskProperty prototype
-        // extensions. To be removed when replaced with proper public API.
-        TaskProperty.prototype[key].call(this, value);
-      } else {
-        assert(
-          `Task option '${key}' is not recognized as a supported option.`,
-          false
-        );
-      }
+  getModifier(name) {
+    let modifier = super.getModifier(name);
+    if (!modifier && typeof TaskProperty.prototype[name] === 'function') {
+      // Shim for compatibility with user-defined TaskProperty prototype
+      // extensions. To be removed when replaced with proper public API.
+      modifier = TaskProperty.prototype[name].bind(this);
     }
+
+    assert(
+      `Task option '${name}' is not recognized as a supported option.`,
+      modifier
+    );
+
+    return modifier;
+  }
+
+  getScheduler(schedulerPolicy, onStateCallback) {
+    return new EmberScheduler(schedulerPolicy, onStateCallback);
   }
 
   _setupEmberKVO(proto) {
@@ -247,35 +163,6 @@ export class TaskFactory {
     );
   }
 
-  _sharedTaskProperties(context) {
-    let group, scheduler;
-    let onStateCallback = this._onStateCallback;
-
-    if (this._taskGroupPath) {
-      group = context[this._taskGroupPath];
-      assert(
-        `ember-concurrency: Expected group '${this._taskGroupPath}' to be defined but was not found.`,
-        group instanceof TaskGroup
-      );
-      scheduler = group.scheduler;
-    } else {
-      let schedulerPolicy = new this._schedulerPolicyClass(
-        this._maxConcurrency
-      );
-      scheduler = new EmberScheduler(schedulerPolicy, onStateCallback);
-    }
-
-    return {
-      context,
-      debug: this._debug,
-      name: this.name,
-      group,
-      scheduler,
-      hasEnabledEvents: this._hasEnabledEvents,
-      onStateCallback,
-    };
-  }
-
   // Provided for compatibility with ember-concurrency TaskProperty extension
   // methods
   get taskFn() {
@@ -284,17 +171,5 @@ export class TaskFactory {
 
   set taskFn(fn) {
     this.setTaskDefinition(fn);
-  }
-}
-
-export class TaskGroupFactory extends TaskFactory {
-  createTaskGroup(context) {
-    assert(
-      `A task definition is not expected for a task group.`,
-      !this.taskDefinition
-    );
-    let options = this._sharedTaskProperties(context);
-
-    return new TaskGroup(options);
   }
 }

--- a/addon/-private/task-properties.js
+++ b/addon/-private/task-properties.js
@@ -10,7 +10,7 @@ import {
   task as taskDecorator,
   taskGroup as taskGroupDecorator,
 } from './task-decorators';
-import { TaskFactory, TaskGroupFactory } from './task-factory';
+import { TaskFactory } from './task-factory';
 
 let taskFactorySymbol = '__ec_task_factory';
 
@@ -431,7 +431,7 @@ export function taskGroup(possibleDecoratorOptions, key, descriptor) {
       return tp[taskFactorySymbol].createTaskGroup(this);
     });
 
-    tp[taskFactorySymbol] = new TaskGroupFactory();
+    tp[taskFactorySymbol] = new TaskFactory();
 
     Object.setPrototypeOf(tp, TaskGroupProperty.prototype);
 

--- a/addon/-private/task.js
+++ b/addon/-private/task.js
@@ -158,7 +158,16 @@ export class Task extends BaseTask {
   }
 
   _clone() {
-    return new Task(this.options);
+    return new Task({
+      context: this.context,
+      debug: this.debug,
+      generatorFactory: this.generatorFactory,
+      group: this.group,
+      hasEnabledEvents: this.hasEnabledEvents,
+      name: this.name,
+      onStateCallback: this.onStateCallback,
+      scheduler: this.scheduler
+    });
   }
 
   toString() {

--- a/addon/-private/task.js
+++ b/addon/-private/task.js
@@ -166,7 +166,7 @@ export class Task extends BaseTask {
       hasEnabledEvents: this.hasEnabledEvents,
       name: this.name,
       onStateCallback: this.onStateCallback,
-      scheduler: this.scheduler
+      scheduler: this.scheduler,
     });
   }
 


### PR DESCRIPTION
Some internal refactoring to separate the Ember bits of `TaskFactory`. This will provide some groundwork for a future RFC.