### PR TITLE
Add onError parameter to perform helper

### DIFF
--- a/addon/helpers/perform.js
+++ b/addon/helpers/perform.js
@@ -1,8 +1,38 @@
 import { helper } from '@ember/component/helper';
+import { assert } from '@ember/debug';
 import { taskHelperClosure } from 'ember-concurrency/-private/helpers';
 
+function maybeReportError(onError) {
+  return function (e) {
+    if (typeof onError === 'function') {
+      onError(e);
+    } else if (onError === null) {
+      // Do nothing
+    } else {
+      assert(
+        `The onError argument passed to the \`perform\` helper should be a function or null; you passed ${onError}`,
+        false
+      );
+    }
+  };
+}
+
 export function performHelper(args, hash) {
-  return taskHelperClosure('perform', 'perform', args, hash);
+  let perform = taskHelperClosure('perform', 'perform', args, hash);
+
+  if (hash && typeof hash.onError !== 'undefined') {
+    return function (...innerArgs) {
+      try {
+        let taskInstance = perform(...innerArgs);
+        return taskInstance.catch(maybeReportError(hash.onError));
+        // eslint-disable-next-line no-empty
+      } catch {
+        maybeReportError(hash.onError);
+      }
+    };
+  } else {
+    return perform;
+  }
 }
 
 export default helper(performHelper);


### PR DESCRIPTION
Allows setting to reporting function for reporting to error handlers, etc. Also allows setting to `null` to swallow all errors. This is useful when using the `(perform)` helper with tasks that are always having their error states handled in the UI. In these cases, errors being raised either may be surfaced in the UI and the render errors will be extraneous or there's a desire to log directly to an error reporting service.

Fixes #435 