### PR TITLE
Genericize task perform

### DIFF
--- a/addon/-private/external/environment.js
+++ b/addon/-private/external/environment.js
@@ -1,7 +1,36 @@
 export class Environment {
   assert() {}
-  async() {}
-  reportUncaughtRejection() {}
-  defer() {}
-  globalDebuggingEnabled() {}
+
+  async(callback) {
+    Promise.resolve().then(callback);
+  }
+
+  reportUncaughtRejection() {
+    this.async((error) => {
+      throw error;
+    });
+  }
+
+  defer() {
+    let deferable = {
+      promise: null,
+      resolve: null,
+      reject: null,
+    };
+
+    let promise = new Promise((resolve, reject) => {
+      deferable.resolve = resolve;
+      deferable.reject = reject;
+    });
+
+    deferable.promise = promise;
+
+    return deferable;
+  }
+
+  globalDebuggingEnabled() {
+    return false;
+  }
 }
+
+export const DEFAULT_ENVIRONMENT = new Environment();

--- a/addon/-private/external/task-factory.js
+++ b/addon/-private/external/task-factory.js
@@ -6,6 +6,7 @@ import KeepLatestSchedulerPolicy from './scheduler/policies/keep-latest-policy';
 import RestartableSchedulerPolicy from './scheduler/policies/restartable-policy';
 import { Task } from './task/task';
 import { TaskGroup } from './task/task-group';
+import { DEFAULT_ENVIRONMENT } from './environment';
 
 function assertModifiersNotMixedWithGroup(obj) {
   if (obj._hasSetConcurrencyConstraint && obj._taskGroupPath) {
@@ -96,6 +97,8 @@ export function hasModifier(name) {
  * @class TaskFactory
  */
 export class TaskFactory {
+  env = DEFAULT_ENVIRONMENT;
+
   _debug = null;
   _enabledModifiers = [];
   _hasSetConcurrencyConstraint = false;
@@ -215,6 +218,7 @@ export class TaskFactory {
     return {
       context,
       debug: this._debug,
+      env: this.env,
       name: this.name,
       group,
       scheduler,

--- a/addon/-private/external/task/taskable.js
+++ b/addon/-private/external/task/taskable.js
@@ -14,6 +14,7 @@ export class Taskable {
     this.context = options.context;
     this.debug = options.debug || false;
     this.enabledModifiers = options.enabledModifiers;
+    this.env = options.env;
     this.group = options.group;
     this.hasEnabledEvents = options.hasEnabledEvents;
     this.modifierOptions = options.modifierOptions;
@@ -42,6 +43,10 @@ export class Taskable {
         this._resetState();
       }
     });
+  }
+
+  get _isAlive() {
+    return true;
   }
 
   _resetState() {

--- a/addon/-private/task-factory.js
+++ b/addon/-private/task-factory.js
@@ -12,6 +12,7 @@ import { Task, EncapsulatedTask } from './task';
 import { TaskProperty } from './task-properties';
 import { TaskGroup } from './task-group';
 import EmberScheduler from './scheduler/ember-scheduler';
+import { EMBER_ENVIRONMENT } from './ember-environment';
 
 let handlerCounter = 0;
 
@@ -60,6 +61,8 @@ registerModifier('on', (factory, eventNames) =>
 );
 
 export class TaskFactory extends BaseTaskFactory {
+  env = EMBER_ENVIRONMENT;
+
   createTask(context) {
     assert(
       `Cannot create task if a task definition is not provided as generator function or encapsulated task.`,


### PR DESCRIPTION
Moves the `Task` perform logic into the `external` module and provides a real generic `Environment` implementation