### PR TITLE
Simplify async fn API to just `task(async () => {})`

### DIFF
--- a/addon/-private/async-arrow-runtime.js
+++ b/addon/-private/async-arrow-runtime.js
@@ -1,18 +1,12 @@
 import { TaskFactory } from './task-factory';
 
 /**
- * Instantiate and return a Task object that is bound to (i.e. its lifetime is intertwined with)
- * the `context` param (e.g. a Component or other class defined with modern ES6 class syntax).
+ * This builder function is called by the transpiled code from
+ * `task(async () => {})`. See lib/babel-plugin-transform-ember-concurrency-async-tasks.js
  *
  * @private
  */
-export function buildTask(
-  context,
-  options,
-  taskGeneratorFn,
-  taskName,
-  bufferPolicyName
-) {
+export function buildTask(contextFn, options, taskName, bufferPolicyName) {
   let optionsWithBufferPolicy = options;
 
   if (bufferPolicyName) {
@@ -20,10 +14,12 @@ export function buildTask(
     optionsWithBufferPolicy[bufferPolicyName] = true;
   }
 
+  const result = contextFn();
+
   const taskFactory = new TaskFactory(
     taskName || '<unknown>',
-    taskGeneratorFn,
+    result.generator,
     optionsWithBufferPolicy
   );
-  return taskFactory.createTask(context);
+  return taskFactory.createTask(result.context);
 }

--- a/addon/-private/task-public-api.js
+++ b/addon/-private/task-public-api.js
@@ -60,7 +60,7 @@ import { assert } from '@ember/debug';
  */
 export function task(taskFnOrProtoOrDecoratorOptions, key, descriptor) {
   assert(
-    `It appears you're attempting to use the new task(this, async () => { ... }) syntax, but the async arrow task function you've provided is not being properly compiled by Babel.\n\nPossible causes / remedies:\n\n1. You must pass the async function expression directly to the task() function (it is not currently supported to pass in a variable containing the async arrow fn, or any other kind of indirection)\n2. If this code is in an addon, please ensure the addon specificies ember-concurrency "2.3.0" or higher in "dependencies" (not "devDependencies")\n3. Ensure that there is only one version of ember-concurrency v2.3.0+ being used in your project (including nested dependencies) and consider using npm/yarn/pnpm resolutions to enforce a single version is used`,
+    `It appears you're attempting to use the new task(async () => { ... }) syntax, but the async arrow task function you've provided is not being properly compiled by Babel.\n\nPossible causes / remedies:\n\n1. You must pass the async function expression directly to the task() function (it is not currently supported to pass in a variable containing the async arrow fn, or any other kind of indirection)\n2. If this code is in an addon, please ensure the addon specificies ember-concurrency "2.3.0" or higher in "dependencies" (not "devDependencies")\n3. Ensure that there is only one version of ember-concurrency v2.3.0+ being used in your project (including nested dependencies) and consider using npm/yarn/pnpm resolutions to enforce a single version is used`,
     !isUntranspiledAsyncFn(arguments[arguments.length - 1])
   );
 

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -924,6 +924,11 @@ export function task<
 
 export function task<
   HostObject,
+  T extends AsyncArrowTaskFunction<HostObject, any, any[]>
+>(asyncArrowTaskFn: T): TaskForAsyncTaskFunction<HostObject, T>;
+
+export function task<
+  HostObject,
   O extends TaskOptions,
   T extends AsyncArrowTaskFunction<HostObject, any, any[]>
 >(
@@ -931,6 +936,12 @@ export function task<
   baseOptions: O,
   asyncArrowTaskFn: T
 ): TaskForAsyncTaskFunction<HostObject, T>;
+
+export function task<
+  HostObject,
+  O extends TaskOptions,
+  T extends AsyncArrowTaskFunction<HostObject, any, any[]>
+>(baseOptions: O, asyncArrowTaskFn: T): TaskForAsyncTaskFunction<HostObject, T>;
 
 export type AsyncTaskFunction<T, Args extends any[]> = (
   ...args: Args

--- a/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
+++ b/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
@@ -111,7 +111,7 @@ function convertFunctionExpressionIntoGenerator(
     if (isArrowFunctionExpression(path)) {
       // At this point we have something that looks like
       //
-      //    foo = task(this, {}?, async () => {})
+      //    foo = task(this?, {}?, async () => {})
       //
       // and we need to convert it to
       //
@@ -217,10 +217,10 @@ const TransformAwaitIntoYield = {
 };
 
 /**
- * Extract the name of the task, e.g. `foo = task(this, async () => {})` has a task name of "foo".
+ * Extract the name of the task, e.g. `foo = task(async () => {})` has a task name of "foo".
  * Classic ember-concurrency APIs (and decorators-based ones) know the name of the task, which we
  * used for error messages and other diagnostic / debugging functionality, but the newer
- * `foo = task(this, async () => {})` API needs a bit of help from this transform to determine the name;
+ * `foo = task(async () => {})` API needs a bit of help from this transform to determine the name;
  * in this method we extract the name from the ClassProperty assignment so that we can pass it in
  * to the options hash when constructing the Task.
  *

--- a/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
+++ b/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
@@ -6,8 +6,14 @@ const {
   isArrowFunctionExpression,
   stringLiteral,
   nullLiteral,
+  identifier,
   blockStatement,
   returnStatement,
+  objectExpression,
+  objectProperty,
+  thisExpression,
+  arrowFunctionExpression,
+  callExpression,
 } = require('@babel/types');
 
 const { addNamed } = require('@babel/helper-module-imports');
@@ -109,19 +115,35 @@ function convertFunctionExpressionIntoGenerator(
       //
       // and we need to convert it to
       //
-      //    foo = buildTask(this, options | null, generatorFn, taskName, bufferPolicyName?)
+      //    foo = buildTask(contextFn, options | null, taskName, bufferPolicyName?)
+      //
+      // where conextFn is
+      //
+      //    () => ({ context: this, generator: function * () { ... } })
 
       // Replace the async arrow fn with a generator fn
-      let body = path.node.body;
-      if (body.type !== 'BlockStatement') {
+      let asyncArrowFnBody = path.node.body;
+      if (asyncArrowFnBody.type !== 'BlockStatement') {
         // Need to convert `async () => expr` with `async () => { return expr }`
-        body = blockStatement([returnStatement(body)]);
+        asyncArrowFnBody = blockStatement([returnStatement(asyncArrowFnBody)]);
       }
-      path.replaceWith(
-        functionExpression(path.node.id, path.node.params, body, true)
+
+      const taskGeneratorFn = functionExpression(
+        path.node.id,
+        path.node.params,
+        asyncArrowFnBody,
+        true
       );
 
-      // Add an import to buildTask
+      const contextFn = arrowFunctionExpression(
+        [],
+        objectExpression([
+          objectProperty(identifier('context'), thisExpression()),
+          objectProperty(identifier('generator'), taskGeneratorFn),
+        ])
+      );
+
+      // Add an import to buildTask (if one hasn't already been added)
       if (!state._buildTaskImport) {
         state._buildTaskImport = addNamed(
           state.root,
@@ -130,31 +152,63 @@ function convertFunctionExpressionIntoGenerator(
         );
       }
 
-      // Rename `task()` to `buildTask()`
-      path.parentPath.node.callee.name = state._buildTaskImport.name;
+      const originalArgs = path.parentPath.node.arguments;
 
-      // If there's only 2 args (e.g. `task(this, async () => {})`), add null where `options` would be.
-      if (path.parentPath.node.arguments.length === 2) {
-        path.parentPath.node.arguments.splice(1, 0, nullLiteral());
+      // task(this, async() => {}) was the original API, but we don't actually
+      // need the `this` arg (we determine the `this` context from the contextFn async arrow fn)
+      if (originalArgs[0] && originalArgs[0].type === 'ThisExpression') {
+        originalArgs.shift();
       }
 
-      // Push taskName to the `task()` fn call.
       const taskName = extractTaskNameFromClassProperty(path);
-      path.parentPath.node.arguments.push(stringLiteral(taskName));
+      let optionsOrNull;
+
+      // remaining args should either be [options, async () => {}] or [async () => {}]
+      switch (originalArgs.length) {
+        case 1:
+          optionsOrNull = nullLiteral();
+          break;
+        case 2:
+          optionsOrNull = originalArgs[0];
+          break;
+        default:
+          throw new Error(
+            `The task() syntax you're using for the task named ${taskName} is incorrect.`
+          );
+      }
 
       // Push buffer policy name to `buildTask()`
       const bufferPolicyName =
         FACTORY_FUNCTION_BUFFER_POLICY_MAPPING[factoryFunctionName];
-      if (bufferPolicyName) {
-        path.parentPath.node.arguments.push(stringLiteral(bufferPolicyName));
-      }
+
+      // buildTask(contextFn, options | null, taskName, bufferPolicyName?)
+      const buildTaskCall = callExpression(
+        identifier(state._buildTaskImport.name),
+        [
+          contextFn,
+          optionsOrNull,
+          stringLiteral(taskName),
+          bufferPolicyName ? stringLiteral(bufferPolicyName) : nullLiteral(),
+        ]
+      );
+
+      let newPath = path.parentPath.replaceWith(buildTaskCall)[0];
+      newPath.traverse({
+        FunctionExpression(path) {
+          if (!path.node.generator) {
+            return;
+          }
+          path.traverse(TransformAwaitIntoYield);
+        },
+      });
     }
-    path.traverse(TransformAwaitIntoYield);
   }
 }
 
 const TransformAwaitIntoYield = {
   Function(path) {
+    // This ensures we don't recurse into more deeply nested functions that
+    // aren't supposed to be converted from await -> yield.
     path.skip();
   },
   AwaitExpression(path) {

--- a/tests/dummy/app/components/ajax-throttling-example/component.js
+++ b/tests/dummy/app/components/ajax-throttling-example/component.js
@@ -17,7 +17,7 @@ export default class AjaxThrottlingExampleComponent extends Component {
   tagName = '';
   logs = [];
 
-  ajaxTask = enqueueTask(this, { maxConcurrency: 3 }, async () => {
+  ajaxTask = enqueueTask({ maxConcurrency: 3 }, async () => {
     // simulate slow AJAX
     await timeout(2000 + 2000 * Math.random());
     return {};

--- a/tests/dummy/app/components/caps-marquee/component.js
+++ b/tests/dummy/app/components/caps-marquee/component.js
@@ -14,7 +14,7 @@ export default class CapsMarqueeComponent extends Component {
   scrambledText = null;
 
   // BEGIN-SNIPPET caps-marquee
-  marqueeLoop = task(this, { on: 'init' }, async () => {
+  marqueeLoop = task({ on: 'init' }, async () => {
     let text = this.text;
     while (true) {
       this.set('formattedText', text);

--- a/tests/dummy/app/components/concurrency-graph/component.js
+++ b/tests/dummy/app/components/concurrency-graph/component.js
@@ -52,7 +52,7 @@ export default class ConcurrencyGraphComponent extends Component {
     return Math.max(10000, timeElapsed);
   }
 
-  ticker = task(this, { drop: true }, async () => {
+  ticker = task({ drop: true }, async () => {
     while (true) {
       let now = +new Date();
       this.set('timeElapsed', now - this.startTime);

--- a/tests/dummy/app/components/count-up/component.js
+++ b/tests/dummy/app/components/count-up/component.js
@@ -6,7 +6,7 @@ export default class CountUpComponent extends Component {
   count = 0;
 
   // BEGIN-SNIPPET count-up
-  countUp = task(this, { on: 'init' }, async () => {
+  countUp = task({ on: 'init' }, async () => {
     while (true) {
       this.incrementProperty('count');
       await timeout(100);

--- a/tests/dummy/app/components/events-example/component.js
+++ b/tests/dummy/app/components/events-example/component.js
@@ -14,7 +14,7 @@ export default class EventsExampleComponent extends Component.extend(Evented) {
   // BEGIN-SNIPPET waitForEvent
   domEvent = null;
 
-  domEventLoop = task(this, async () => {
+  domEventLoop = task(async () => {
     while (true) {
       let event = await waitForEvent(document.body, 'click');
       this.set('domEvent', event);
@@ -24,7 +24,7 @@ export default class EventsExampleComponent extends Component.extend(Evented) {
 
   jQueryEvent = null;
 
-  jQueryEventLoop = task(this, async () => {
+  jQueryEventLoop = task(async () => {
     let $body = $('body');
     while (true) {
       let event = await waitForEvent($body, 'click');
@@ -34,7 +34,7 @@ export default class EventsExampleComponent extends Component.extend(Evented) {
 
   emberEvent = null;
 
-  emberEventedLoop = task(this, async () => {
+  emberEventedLoop = task(async () => {
     while (true) {
       let event = await waitForEvent(this, 'fooEvent');
       this.set('emberEvent', event);
@@ -52,14 +52,14 @@ export default class EventsExampleComponent extends Component.extend(Evented) {
   // END-SNIPPET
 
   // BEGIN-SNIPPET waitForEvent-derived-state
-  waiterLoop = task(this, async () => {
+  waiterLoop = task(async () => {
     while (true) {
       await this.waiter.perform();
       await timeout(1500);
     }
   });
 
-  waiter = task(this, async () => {
+  waiter = task(async () => {
     let event = await waitForEvent(document.body, 'click');
     return event;
   });
@@ -67,7 +67,7 @@ export default class EventsExampleComponent extends Component.extend(Evented) {
   // END-SNIPPET
 
   // BEGIN-SNIPPET waitForProperty
-  startAll = task(this, async () => {
+  startAll = task(async () => {
     this.set('bazValue', 1);
     this.set('state', 'Start.');
     this.foo.perform();
@@ -75,11 +75,11 @@ export default class EventsExampleComponent extends Component.extend(Evented) {
     this.baz.perform();
   });
 
-  foo = task(this, async () => {
+  foo = task(async () => {
     await timeout(500);
   });
 
-  bar = task(this, async () => {
+  bar = task(async () => {
     await waitForProperty(this, 'foo.isIdle');
     this.set('state', `${this.state} Foo is idle.`);
     await timeout(500);
@@ -89,7 +89,7 @@ export default class EventsExampleComponent extends Component.extend(Evented) {
 
   bazValue = 1;
 
-  baz = task(this, async () => {
+  baz = task(async () => {
     let val = await waitForProperty(this, 'bazValue', (v) => v % 2 === 0);
     await timeout(500);
     this.set('state', `${this.state} Baz got even value ${val}.`);

--- a/tests/dummy/app/components/scrambled-text/component.js
+++ b/tests/dummy/app/components/scrambled-text/component.js
@@ -21,7 +21,7 @@ export default class ScrambledTextComponent extends Component {
   scrambledText = null;
 
   // BEGIN-SNIPPET scrambled-text
-  startScrambling = task(this, { on: 'init' }, async () => {
+  startScrambling = task({ on: 'init' }, async () => {
     let text = this.text;
     while (true) {
       let pauseTime = 140;

--- a/tests/dummy/app/components/start-task-example/component.js
+++ b/tests/dummy/app/components/start-task-example/component.js
@@ -8,7 +8,7 @@ export default class StartTaskExampleComponent extends Component {
 
   status = null;
 
-  myTask = task(this, { on: ['init', 'foo'] }, async (msg = 'init') => {
+  myTask = task({ on: ['init', 'foo'] }, async (msg = 'init') => {
     let status = `myTask.perform(${msg})...`;
     this.set('status', status);
 

--- a/tests/dummy/app/components/task-function-syntax-1/component.js
+++ b/tests/dummy/app/components/task-function-syntax-1/component.js
@@ -6,7 +6,7 @@ export default class TaskFunctionSyntaxComponent1 extends Component {
   status = null;
 
   // BEGIN-SNIPPET task-function-syntax-1
-  waitAFewSeconds = task(this, async () => {
+  waitAFewSeconds = task(async () => {
     this.set('status', 'Gimme one second...');
     await timeout(1000);
     this.set('status', 'Gimme one more second...');

--- a/tests/dummy/app/components/task-function-syntax-2/component.js
+++ b/tests/dummy/app/components/task-function-syntax-2/component.js
@@ -6,7 +6,7 @@ export default class TaskFunctionSyntaxComponent2 extends Component {
   status = null;
 
   // BEGIN-SNIPPET task-function-syntax-2
-  pickRandomNumbers = task(this, async () => {
+  pickRandomNumbers = task(async () => {
     let nums = [];
     for (let i = 0; i < 3; i++) {
       nums.push(Math.floor(Math.random() * 10));

--- a/tests/dummy/app/components/task-function-syntax-3/component.js
+++ b/tests/dummy/app/components/task-function-syntax-3/component.js
@@ -6,7 +6,7 @@ export default class TaskFunctionSyntaxComponent3 extends Component {
   status = null;
 
   // BEGIN-SNIPPET task-function-syntax-3
-  myTask = task(this, async () => {
+  myTask = task(async () => {
     this.set('status', `Thinking...`);
     let promise = timeout(1000).then(() => 123);
     let resolvedValue = await promise;

--- a/tests/dummy/app/components/task-function-syntax-4/component.js
+++ b/tests/dummy/app/components/task-function-syntax-4/component.js
@@ -6,7 +6,7 @@ export default class TaskFunctionSyntaxComponent4 extends Component {
   status = null;
 
   // BEGIN-SNIPPET task-function-syntax-4
-  myTask = task(this, async () => {
+  myTask = task(async () => {
     this.set('status', `Thinking...`);
     try {
       await timeout(1000).then(() => {

--- a/tests/dummy/app/components/tutorial-6/component.js
+++ b/tests/dummy/app/components/tutorial-6/component.js
@@ -6,7 +6,7 @@ import { task } from 'ember-concurrency';
 export default class Tutorial6 extends TutorialComponent {
   result = null;
 
-  findStores = task(this, async () => {
+  findStores = task(async () => {
     let geolocation = this.geolocation;
     let store = this.store;
 

--- a/tests/dummy/app/components/tutorial-7/component.js
+++ b/tests/dummy/app/components/tutorial-7/component.js
@@ -6,7 +6,7 @@ import { task } from 'ember-concurrency';
 export default class Tutorial7 extends TutorialComponent {
   result = null;
 
-  findStores = task(this, async () => {
+  findStores = task(async () => {
     let geolocation = this.geolocation;
     let store = this.store;
 

--- a/tests/dummy/app/components/tutorial-8/component.js
+++ b/tests/dummy/app/components/tutorial-8/component.js
@@ -6,7 +6,7 @@ import { task } from 'ember-concurrency';
 export default class Tutorial8 extends TutorialComponent {
   result = null;
 
-  findStores = task(this, { drop: true }, async () => { // ++
+  findStores = task({ drop: true }, async () => { // ++
     let geolocation = this.geolocation;
     let store = this.store;
 

--- a/tests/dummy/app/components/tutorial-9/component.js
+++ b/tests/dummy/app/components/tutorial-9/component.js
@@ -6,7 +6,7 @@ import { task } from 'ember-concurrency';
 export default class Tutorial9 extends TutorialComponent {
   result = null;
 
-  findStores = task(this, { drop: true }, async () => {
+  findStores = task({ drop: true }, async () => {
     let geolocation = this.geolocation;
     let store = this.store;
 

--- a/tests/dummy/app/docs/advanced/task-modifiers/controller.js
+++ b/tests/dummy/app/docs/advanced/task-modifiers/controller.js
@@ -17,7 +17,7 @@ let performance =
     : { getEntriesByName() {} };
 
 export default class TaskModifiersController extends Controller {
-  doWork = task(this, { drop: true, benchmark: true }, async () => {
+  doWork = task({ drop: true, benchmark: true }, async () => {
     await timeout(20000 * Math.random());
   });
 

--- a/tests/dummy/app/docs/cancelation/controller.js
+++ b/tests/dummy/app/docs/cancelation/controller.js
@@ -7,7 +7,7 @@ export default class CancelationController extends Controller {
   count = 0;
   mostRecent = null;
 
-  myTask = task(this, async () => {
+  myTask = task(async () => {
     try {
       this.incrementProperty('count');
       await forever;

--- a/tests/dummy/app/docs/child-tasks/controller.js
+++ b/tests/dummy/app/docs/child-tasks/controller.js
@@ -5,7 +5,7 @@ import { restartableTask, task, timeout } from 'ember-concurrency';
 export default class ChildTasksController extends Controller {
   status = 'Waiting to start';
 
-  parentTask = restartableTask(this, async () => {
+  parentTask = restartableTask(async () => {
     this.set('status', '1. Parent: one moment...');
     await timeout(1000);
     let value = await this.childTask.perform();
@@ -14,7 +14,7 @@ export default class ChildTasksController extends Controller {
     this.set('status', '6. Done!');
   });
 
-  childTask = task(this, async () => {
+  childTask = task(async () => {
     this.set('status', '2. Child: one moment...');
     await timeout(1000);
     let value = await this.grandchildTask.perform();
@@ -23,7 +23,7 @@ export default class ChildTasksController extends Controller {
     return "What's up";
   });
 
-  grandchildTask = task(this, async () => {
+  grandchildTask = task(async () => {
     this.set('status', '3. Grandchild: one moment...');
     await timeout(1000);
     return 'Hello';

--- a/tests/dummy/app/docs/error-vs-cancelation/controller.js
+++ b/tests/dummy/app/docs/error-vs-cancelation/controller.js
@@ -7,7 +7,7 @@ export default class ErrorVsCancelationController extends Controller {
   numErrors = 0;
   numFinallys = 0;
 
-  myTask = restartableTask(this, async (doError) => {
+  myTask = restartableTask(async (doError) => {
     try {
       await timeout(1000);
       if (doError) {

--- a/tests/dummy/app/docs/examples/autocomplete/controller.js
+++ b/tests/dummy/app/docs/examples/autocomplete/controller.js
@@ -5,7 +5,7 @@ import { restartableTask, task, timeout } from 'ember-concurrency';
 // BEGIN-SNIPPET debounced-search-with-cancelation
 const DEBOUNCE_MS = 250;
 export default class AutocompleteController extends Controller {
-  searchRepo = restartableTask(this, async (term) => {
+  searchRepo = restartableTask(async (term) => {
     if (isBlank(term)) {
       return [];
     }
@@ -26,7 +26,7 @@ export default class AutocompleteController extends Controller {
     return json.items.slice(0, 10);
   });
 
-  getJSON = task(this, async (url) => {
+  getJSON = task(async (url) => {
     let controller = new AbortController();
     let signal = controller.signal;
 

--- a/tests/dummy/app/docs/examples/increment-buttons/controller.js
+++ b/tests/dummy/app/docs/examples/increment-buttons/controller.js
@@ -5,7 +5,7 @@ import { task, timeout } from 'ember-concurrency';
 export default class IncrementButtonsController extends Controller {
   count = 0;
 
-  incrementBy = task(this, async (inc) => {
+  incrementBy = task(async (inc) => {
     let speed = 400;
     while (true) {
       this.incrementProperty('count', inc);

--- a/tests/dummy/app/docs/examples/joining-tasks/controller.js
+++ b/tests/dummy/app/docs/examples/joining-tasks/controller.js
@@ -11,7 +11,7 @@ export default class JoiningTasksController extends Controller {
   colors = ['#ff8888', '#88ff88', '#8888ff'];
   status = 'Waiting...';
 
-  parent = task(this, { restartable: true }, async (methodName) => {
+  parent = task({ restartable: true }, async (methodName) => {
     let allOrRace = methods[methodName];
     let childTasks = [];
 

--- a/tests/dummy/app/docs/examples/loading-ui/controller.js
+++ b/tests/dummy/app/docs/examples/loading-ui/controller.js
@@ -5,7 +5,7 @@ import { dropTask, timeout } from 'ember-concurrency';
 export default class LoadingUIController extends Controller {
   result = null;
 
-  askQuestion = dropTask(this, async () => {
+  askQuestion = dropTask(async () => {
     await timeout(1000);
     this.set('result', Math.random());
   });

--- a/tests/dummy/app/docs/examples/route-tasks/detail/route.js
+++ b/tests/dummy/app/docs/examples/route-tasks/detail/route.js
@@ -16,7 +16,7 @@ export default class RouteTasksDetailRoute extends Route {
     this.pollServerForChanges.cancelAll();
   }
 
-  pollServerForChanges = restartableTask(this, async (id) => {
+  pollServerForChanges = restartableTask(async (id) => {
     let notify = this.notify;
     await timeout(500);
     try {

--- a/tests/dummy/app/docs/task-concurrency-advanced/controller.js
+++ b/tests/dummy/app/docs/task-concurrency-advanced/controller.js
@@ -8,11 +8,11 @@ export default class SharedTasksController extends Controller {
     async (t) => this.sharedTask.perform(t)
   );
 
-  enqueuedTask3 = task(this, { maxConcurrency: 3, enqueue: true }, async (t) =>
+  enqueuedTask3 = task({ maxConcurrency: 3, enqueue: true }, async (t) =>
     this.sharedTask.perform(t)
   );
 
-  droppingTask3 = task(this, { maxConcurrency: 3, drop: true }, async (t) =>
+  droppingTask3 = task({ maxConcurrency: 3, drop: true }, async (t) =>
     this.sharedTask.perform(t)
   );
 
@@ -22,7 +22,7 @@ export default class SharedTasksController extends Controller {
     async (t) => this.sharedTask.perform(t)
   );
 
-  sharedTask = task(this, async (tracker) => {
+  sharedTask = task(async (tracker) => {
     tracker.start();
     try {
       // simulate async work
@@ -35,9 +35,9 @@ export default class SharedTasksController extends Controller {
 
 /*
 // BEGIN-SNIPPET shared-tasks-concurrent
-  restartableTask3 = task(this, { maxConcurrency: 3, restartable: true }, async (t) => { ... }
-  enqueuedTask3 = task(this, { maxConcurrency: 3, enqueue: true }, async (t) => { ... }
-  droppingTask3 = task(this, { maxConcurrency: 3, drop: true }, async (t) => { ... }
-  keepLatestTask3 = task(this, { maxConcurrency: 3, keepLatest: true }, async (t) => { ... }
+  restartableTask3 = task({ maxConcurrency: 3, restartable: true }, async (t) => { ... }
+  enqueuedTask3 = task({ maxConcurrency: 3, enqueue: true }, async (t) => { ... }
+  droppingTask3 = task({ maxConcurrency: 3, drop: true }, async (t) => { ... }
+  keepLatestTask3 = task({ maxConcurrency: 3, keepLatest: true }, async (t) => { ... }
 // END-SNIPPET
 */

--- a/tests/dummy/app/docs/task-concurrency/controller.js
+++ b/tests/dummy/app/docs/task-concurrency/controller.js
@@ -2,25 +2,25 @@ import Controller from '@ember/controller';
 import { task, timeout } from 'ember-concurrency';
 
 export default class SharedTasksController extends Controller {
-  defaultTask = task(this, async (t) => this.sharedTask.perform(t));
+  defaultTask = task(async (t) => this.sharedTask.perform(t));
 
-  restartableTask = task(this, { restartable: true }, async (t) =>
+  restartableTask = task({ restartable: true }, async (t) =>
     this.sharedTask.perform(t)
   );
 
-  enqueuedTask = task(this, { enqueue: true }, async (t) =>
+  enqueuedTask = task({ enqueue: true }, async (t) =>
     this.sharedTask.perform(t)
   );
 
-  droppingTask = task(this, { drop: true }, async (t) =>
+  droppingTask = task({ drop: true }, async (t) =>
     this.sharedTask.perform(t)
   );
 
-  keepLatestTask = task(this, { keepLatest: true }, async (t) =>
+  keepLatestTask = task({ keepLatest: true }, async (t) =>
     this.sharedTask.perform(t)
   );
 
-  sharedTask = task(this, async (tracker) => {
+  sharedTask = task(async (tracker) => {
     tracker.start();
     try {
       // simulate async work
@@ -33,10 +33,10 @@ export default class SharedTasksController extends Controller {
 
 /*
 // BEGIN-SNIPPET shared-tasks
-  defaultTask = task(this, async (t) => { ... });
-  restartableTask = task(this, { restartable: true }, async (t) => { ... }
-  enqueuedTask = task(this, { enqueue: true }, async (t) => { ... }
-  droppingTask = task(this, { drop: true }, async (t) => { ... }
-  keepLatestTask = task(this, { keepLatest: true }, async (t) => { ... }
+  defaultTask = task(async (t) => { ... });
+  restartableTask = task({ restartable: true }, async (t) => { ... }
+  enqueuedTask = task({ enqueue: true }, async (t) => { ... }
+  droppingTask = task({ drop: true }, async (t) => { ... }
+  keepLatestTask = task({ keepLatest: true }, async (t) => { ... }
 // END-SNIPPET
 */

--- a/tests/dummy/app/docs/typescript/template.hbs
+++ b/tests/dummy/app/docs/typescript/template.hbs
@@ -28,7 +28,7 @@
 <p>
   Support for TypeScript in ember-concurrency was recently greatly improved and simplified
   with the release of version 2.3, largely due to the introduction of the new
-  async arrow task function syntax (e.g. <code>myTask = task(this, async () => {})</code>),
+  async arrow task function syntax (e.g. <code>myTask = task(async () => {})</code>),
   which alleviated most / all of the prior challenges with getting ember-concurrency tasks
   to play nicely with TypeScript.
 </p>

--- a/tests/dummy/app/helpers-test/controller.js
+++ b/tests/dummy/app/helpers-test/controller.js
@@ -6,7 +6,7 @@ export default class HelpersTestController extends Controller {
   maybeNullTask = null;
   status = null;
 
-  myTask = task(this, async (...args) => {
+  myTask = task(async (...args) => {
     try {
       this.set('status', args.join('-'));
       await forever;
@@ -15,18 +15,18 @@ export default class HelpersTestController extends Controller {
     }
   });
 
-  valueTask = task(this, async (value) => {
+  valueTask = task(async (value) => {
     let expected = 'Set value option';
     if (value !== expected) {
       throw new Error(`value !== ${expected}`);
     }
   });
 
-  returnValue = task(this, async () => {
+  returnValue = task(async () => {
     return 10;
   });
 
-  someTask = task(this, async () => {
+  someTask = task(async () => {
     this.set('status', 'someTask');
   });
 

--- a/tests/dummy/app/testing-ergo/foo/controller.js
+++ b/tests/dummy/app/testing-ergo/foo/controller.js
@@ -5,7 +5,7 @@ import { task, timeout } from 'ember-concurrency';
 export default class FooController extends Controller {
   isShowingButton = false;
 
-  showButtonSoon = task(this, async () => {
+  showButtonSoon = task(async () => {
     this.set('isShowingButton', false);
     await timeout(200);
     this.set('isShowingButton', true);

--- a/tests/dummy/snippets/encapsulated-task.js
+++ b/tests/dummy/snippets/encapsulated-task.js
@@ -3,7 +3,7 @@ import { task } from 'ember-concurrency';
 export default class EncapsulatedTaskComponent extends Component {
   outerFoo = 123;
 
-  regularTask = task(this, async value => {
+  regularTask = task(async value => {
     // this is a classic/regular ember-concurrency task,
     // which has direct access to the host object that it
     // lives on via `this`

--- a/tests/dummy/snippets/last-value-decorator.js
+++ b/tests/dummy/snippets/last-value-decorator.js
@@ -3,7 +3,7 @@ import { task } from 'ember-concurrency';
 import { lastValue } from 'ember-concurrency';
 
 export default class ExampleComponent extends Component {
-  someTask = task(this, async () => {
+  someTask = task(async () => {
     // ...
   });
 

--- a/tests/dummy/snippets/poll-loop-break-1.js
+++ b/tests/dummy/snippets/poll-loop-break-1.js
@@ -1,4 +1,4 @@
-  pollForChanges = task(this, async () => {
+  pollForChanges = task(async () => {
     while(true) {
       yield pollServerForChanges();
       if (Ember.testing) { return; }

--- a/tests/dummy/snippets/poll-loop.js
+++ b/tests/dummy/snippets/poll-loop.js
@@ -1,4 +1,4 @@
-  pollForChanges = task(this, async () => {
+  pollForChanges = task(async () => {
     while(true) {
       yield pollServerForChanges();
       yield timeout(5000);

--- a/tests/dummy/snippets/task-cancelation-example-1.js
+++ b/tests/dummy/snippets/task-cancelation-example-1.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { task, timeout } from 'ember-concurrency';
 
 export default class TaskCancelationExampleComponent extends Component {
-  queryServer = task(this, async () => {
+  queryServer = task(async () => {
     await timeout(10000);
     return 123;
   });

--- a/tests/dummy/snippets/task-cancelation-example-2.js
+++ b/tests/dummy/snippets/task-cancelation-example-2.js
@@ -3,7 +3,7 @@ import { action } from '@ember/object';
 import { didCancel, task, timeout } from 'ember-concurrency';
 
 export default class TaskCancelationExampleComponent extends Component {
-  queryServer = task(this, async () => {
+  queryServer = task(async () => {
     await timeout(10000);
     return 123;
   });

--- a/tests/dummy/snippets/task-cancelation-example-3.js
+++ b/tests/dummy/snippets/task-cancelation-example-3.js
@@ -2,12 +2,12 @@ import Component from '@ember/component';
 import { task, timeout } from 'ember-concurrency';
 
 export default class TaskCancelationExampleComponent extends Component {
-  queryServer = task(this, async () => {
+  queryServer = task(async () => {
     await timeout(10000);
     return 123;
   });
 
-  fetchResults = task(this, async () => {
+  fetchResults = task(async () => {
     let results = await this.queryServer.perform();
     this.set('results', results);
   });

--- a/tests/dummy/snippets/task-decorators-1.js
+++ b/tests/dummy/snippets/task-decorators-1.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 
 export default class ExampleComponent extends Component {
-  doStuff = task(this, async () => {
+  doStuff = task(async () => {
     // ...
   });
 

--- a/tests/dummy/snippets/task-group-decorators-1.js
+++ b/tests/dummy/snippets/task-group-decorators-1.js
@@ -5,11 +5,11 @@ export default class ExampleComponent extends Component {
   @taskGroup
   someTaskGroup;
 
-  doStuff = task(this, { group: 'someTaskGroup' }, async () => {
+  doStuff = task({ group: 'someTaskGroup' }, async () => {
     // ...
   });
 
-  doOtherStuff = task(this, { group: 'someTaskGroup' }, async () => {
+  doOtherStuff = task({ group: 'someTaskGroup' }, async () => {
     // ...
   });
 

--- a/tests/dummy/snippets/ts/basic-example.ts
+++ b/tests/dummy/snippets/ts/basic-example.ts
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { task, timeout } from 'ember-concurrency';
 
 export default class extends Component {
-  myTask = task(this, async (ms: number) => {
+  myTask = task(async (ms: number) => {
     await timeout(ms);
     return 'done!';
   });

--- a/tests/dummy/snippets/ts/typing-task.ts
+++ b/tests/dummy/snippets/ts/typing-task.ts
@@ -10,7 +10,7 @@ interface Args {
 }
 
 export default class extends Component<Args> {
-  slowlyComputeStringLength: MyTaskType = task(this, async (ms: number) => {
+  slowlyComputeStringLength: MyTaskType = task(async (ms: number) => {
     await timeout(ms);
 
     const length = await this.args.fooTask.perform(ms);

--- a/tests/dummy/snippets/writing-tasks.js
+++ b/tests/dummy/snippets/writing-tasks.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 import { task } from 'ember-concurrency';
 
 export default class WritingTasksComponent extends Component {
-  myTask = task(this, async () => {
+  myTask = task(async () => {
     alert("hello!");
   });
 }

--- a/tests/dummy/snippets/yieldable-req-idle-cb-task.js
+++ b/tests/dummy/snippets/yieldable-req-idle-cb-task.js
@@ -3,7 +3,7 @@ import { task } from 'ember-concurrency';
 import idleCallback from 'my-app/yieldables/idle-callback';
 
 export class MyComponent extends Component {
-  backgroundTask = task(this, async () => {
+  backgroundTask = task(async () => {
     while (1) {
       await idleCallback();
 

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -3072,7 +3072,7 @@ module('integration tests', () => {
     }
   });
 
-  test('octane async arrow', () => {
+  test('async arrow with first arg `this`', () => {
     class MyComponent extends GlimmerComponent {
       @taskGroup
       foo!: TaskGroup<never>;
@@ -3113,6 +3113,77 @@ module('integration tests', () => {
       cancelOn = task(this, { cancelOn: 'bye' }, async () => {});
       maxConcurrency = task(this, { maxConcurrency: 1 }, async () => {});
       group = task(this, { group: 'foo' }, async () => {});
+
+      @lastValue('myTask') myTaskValue = 'or some default';
+
+      myTask = task(
+        this,
+        { restartable: true },
+        async (immediately: boolean, ms = 500) => {
+          // expect(this).toEqualTypeOf<MyComponent>();
+          expect(this.foo).not.toBeAny();
+          expect(this.foo).toEqualTypeOf<TaskGroup<never>>();
+
+          if (!immediately) {
+            await timeout(ms);
+          }
+
+          let fetchPromise = fetch('/api/data.json');
+          expect(fetchPromise).resolves.toEqualTypeOf<Response>();
+
+          let response: Response = await fetchPromise;
+          expect(response).toEqualTypeOf<Response>();
+
+          let safeResponse: Resolved<typeof fetchPromise> = await fetchPromise;
+          expect(safeResponse).toEqualTypeOf<Response>();
+
+          return 'wow';
+        }
+      );
+    }
+  });
+
+  test('async arrow omitting `this`', () => {
+    class MyComponent extends GlimmerComponent {
+      @taskGroup
+      foo!: TaskGroup<never>;
+
+      normalTask = task(async (immediately: boolean, ms = 500) => {
+        // expect(this).toEqualTypeOf<MyComponent>();
+        expect(this.foo).not.toBeAny();
+        expect(this.foo).toEqualTypeOf<TaskGroup<never>>();
+
+        if (!immediately) {
+          await timeout(ms);
+        }
+
+        let fetchPromise = fetch('/api/data.json');
+        expect(fetchPromise).resolves.toEqualTypeOf<Response>();
+
+        let response: Response = await fetchPromise;
+        expect(response).toEqualTypeOf<Response>();
+
+        let safeResponse: Resolved<typeof fetchPromise> = await fetchPromise;
+        expect(safeResponse).toEqualTypeOf<Response>();
+
+        return 'wow';
+      });
+
+      restartable = task({ restartable: true }, async () => {});
+      enqueue = task({ enqueue: true }, async () => {});
+      drop = task({ drop: true }, async () => {});
+      keepLatest = task({ keepLatest: true }, async () => {});
+      evented = task({ evented: true }, async () => {});
+      debug = task({ debug: true }, async () => {});
+      onState = task({ onState: () => {} }, async () => {});
+      onStateNull = task({ onState: null }, async () => {});
+
+      // Note: these options work even when strictFunctionTypes is enabled, but
+      // turning it on in this repo breaks other things in addon/index.d.ts
+      on = task({ on: 'hi' }, async () => {});
+      cancelOn = task({ cancelOn: 'bye' }, async () => {});
+      maxConcurrency = task({ maxConcurrency: 1 }, async () => {});
+      group = task({ group: 'foo' }, async () => {});
 
       @lastValue('myTask') myTaskValue = 'or some default';
 


### PR DESCRIPTION
Having just released the new API for `task(this, async () => {})`, it dawned on me that with a bit more babel transform magic, we can support an even simpler task API of just:

```
myTask = task(async () => {
  // ...
})
```

rather than having to pass in `this` as the first arg. This seems like an obvious additional win.