### PR TITLE
Fix waitForProperty types, uncomment type tests

### DIFF
--- a/addon/-private/wait-for.js
+++ b/addon/-private/wait-for.js
@@ -196,9 +196,11 @@ export function waitForEvent(object, eventName) {
  * @param {object} object an object (most likely an Ember Object)
  * @param {string} key the property name that is observed for changes
  * @param {function} callbackOrValue a Function that should return a truthy value
- *                                   when the task should continue executing, or
+ *                                   when the task should continue executing,
  *                                   a non-Function value that the watched property
- *                                   needs to equal before the task will continue running
+ *                                   needs to equal before the task will continue running.
+ *                                   If this parameter is omitted, waits for the watched value
+ *                                   to become any truthy value.
  */
 export function waitForProperty(object, key, predicateCallback) {
   return new WaitForPropertyYieldable(object, key, predicateCallback);

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -1495,25 +1495,27 @@ export function waitForEvent(
  *
  * @param object An object (most likely an Ember Object).
  * @param key The property name that is observed for changes.
- * @param callbackOrValue a Function that should return a truthy value
- *   when the task should continue executing, or
+ * @param [callbackOrValue] a Function that should return a truthy value
+ *   when the task should continue executing,
  *   a non-Function value that the watched property
  *   needs to equal before the task will continue running.
+ *   If this parameter is omitted, waits for the watched value
+ *   to become any truthy value.
  */
 export function waitForProperty<O extends object, K extends keyof O>(
   object: O,
   key: K,
-  callbackOrValue: (value: O[K]) => boolean
+  callbackOrValue?: (value: O[K]) => boolean
 ): Yieldable<void>;
 export function waitForProperty(
   object: object,
   key: string,
-  callbackOrValue: (value: unknown) => boolean
+  callbackOrValue?: (value: unknown) => boolean
 ): Yieldable<void>;
 export function waitForProperty<O extends object, K extends keyof O>(
   object: O,
   key: K,
-  callbackOrValue: O[K]
+  callbackOrValue?: O[K]
 ): Yieldable<void>;
 
 /**

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-qunit": "^6.2.0",
-    "expect-type": "^0.7.4",
+    "expect-type": "^0.13.0",
     "jsdoc": "^3.6.6",
     "jsdom": "^16.7.0",
     "loader.js": "^4.7.0",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.4.1",
     "eslint-plugin-qunit": "^6.2.0",
-    "expect-type": "^0.13.0",
+    "expect-type": "0.7.4",
     "jsdoc": "^3.6.6",
     "jsdom": "^16.7.0",
     "loader.js": "^4.7.0",

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -773,13 +773,12 @@ module('unit tests', () => {
     // @ts-expect-error
     t.finally((v) => {});
 
-    // TODO: fix
-    // try {
-    //   let r = await t;
-    //   expect(r).toBeString();
-    // } catch (e) {
-    //   expect(e).toBeAny();
-    // }
+    try {
+      let r = await t;
+      expect(r).toBeString();
+    } catch (e) {
+      expect(e).toBeAny();
+    }
   });
 
   test('TaskProperty', async () => {
@@ -2226,8 +2225,7 @@ module('unit tests', () => {
       let t!: TaskInstance<string>;
       await t;
     } catch (e) {
-      // TODO: fix
-      // expect(e).toBeAny();
+      expect(e).toBeAny();
 
       if (didCancel(e)) {
         expect(e).not.toBeAny();
@@ -2731,22 +2729,22 @@ module('unit tests', () => {
   test('waitForProperty', async () => {
     let obj = { foo: 'foo' };
 
-    // TODO: fix
-    // expect(waitForProperty).toBeCallableWith(obj, 'foo', 'bar');
-    // expect(waitForProperty).toBeCallableWith(
-    //   obj,
-    //   'foo',
-    //   (v: unknown) => v === 'bar'
-    // );
-    // expect(waitForProperty).toBeCallableWith(
-    //   obj,
-    //   'foo',
-    //   (v: string) => v === 'bar'
-    // );
+    expect(waitForProperty).toBeCallableWith(obj, 'foo');
+    expect(waitForProperty).toBeCallableWith(obj, 'foo', 'bar');
+    expect(waitForProperty).toBeCallableWith(
+      obj,
+      'foo',
+      (v: unknown) => v === 'bar'
+    );
+    expect(waitForProperty).toBeCallableWith(
+      obj,
+      'foo',
+      (v: string) => v === 'bar'
+    );
 
-    // expect(waitForProperty).parameters.toEqualTypeOf<
-    //   [object, string | number | symbol, unknown]
-    // >();
+    expect(waitForProperty).parameters.toEqualTypeOf<
+      [object, string | number | symbol, unknown]
+    >();
     expect(waitForProperty).returns.toEqualTypeOf<Yieldable<void>>();
 
     // @ts-expect-error

--- a/yarn.lock
+++ b/yarn.lock
@@ -6503,10 +6503,10 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect-type@^0.7.4:
-  version "0.7.11"
-  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.7.11.tgz#e6d4ba69aa5db383d4c5c1dcc7b439e72480fc30"
-  integrity sha512-wh/Hpbwsumt/yu2gQyw5PLBpVQaWL4j9i2bKrGNaZxyLGfvhRWwuxLoeCmQHCKYFMild0lp8rK+H9haTW3biQg==
+expect-type@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.13.0.tgz#916646a7a73f3ee77039a634ee9035efe1876eb2"
+  integrity sha512-CclevazQfrqo8EvbLPmP7osnb1SZXkw47XPPvUUpeMz4HuGzDltE7CaIt3RLyT9UQrwVK/LDn+KVcC0hcgjgDg==
 
 express@^4.10.7, express@^4.16.2, express@^4.17.1:
   version "4.18.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6503,10 +6503,10 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-expect-type@^0.13.0:
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.13.0.tgz#916646a7a73f3ee77039a634ee9035efe1876eb2"
-  integrity sha512-CclevazQfrqo8EvbLPmP7osnb1SZXkw47XPPvUUpeMz4HuGzDltE7CaIt3RLyT9UQrwVK/LDn+KVcC0hcgjgDg==
+expect-type@0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/expect-type/-/expect-type-0.7.4.tgz#588739f5e86e6713df49ae43812570f11225f9d7"
+  integrity sha512-/ykfDxhYq9vz/EgqH8YTeIehvb9YCP2W7qztpEqm84LaA23nOeGe6+H7huxxfncehig2bV0S0Gyhf+ncUwt2Mg==
 
 express@^4.10.7, express@^4.16.2, express@^4.17.1:
   version "4.18.1"


### PR DESCRIPTION
As part of the work for version 2.3 I forgot that when I bumped some dependencies, I started getting some type failures in `tests/types/ember-concurrency-test.ts`, so I commented those tests out.

This PR attempts to

1. re-enable those specs 
2. Fix the `waitForProperty` type to allow for the 3rd arg to be optional