### PR TITLE
Fix observers in 2.3.0+

### DIFF
--- a/addon/-private/external/task-decorators.js
+++ b/addon/-private/external/task-decorators.js
@@ -1,7 +1,7 @@
 import { TaskFactory } from './task-factory';
 
 function taskFromPropertyDescriptor(
-  _target,
+  target,
   key,
   descriptor,
   params = [],
@@ -23,6 +23,7 @@ function taskFromPropertyDescriptor(
   let tasks = new WeakMap();
   let options = params[0] || {};
   let factory = new factoryClass(key, taskFn, options);
+  factory._setupEmberKVO(target);
 
   return {
     get() {


### PR DESCRIPTION
Closes #481

It seems #457 removed a call to `_setupEmberKVO`, which was causing observers (and probably some other cases) to stop working.