### PR TITLE
Fix typo in documentation

### DIFF
--- a/tests/dummy/app/docs/tutorial/refactor/template.hbs
+++ b/tests/dummy/app/docs/tutorial/refactor/template.hbs
@@ -37,7 +37,7 @@
 {{! template-lint-disable no-unbalanced-curlies }}
 <p>
   Second, in the template, instead of using <code>onclick=\{{action 'findStores'}}</code>,
-  we use <code>onclick=\{{perform findStores}}</code>.
+  we use <code>onclick=\{{perform this.findStores}}</code>.
 </p>
 {{! template-lint-enable no-unbalanced-curlies }}
 


### PR DESCRIPTION
Addresses a small typo in the documentation that omitted the `this`. 