### PR TITLE
Babel: deeply traverse as early as possible

### DIFF
--- a/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
+++ b/lib/babel-plugin-transform-ember-concurrency-async-tasks.js
@@ -254,12 +254,24 @@ module.exports = declare((api) => {
       Program(path, state) {
         // Stash the program root on state so that it's easier to dynamically inject `import` later on
         state.root = path;
-      },
-      ClassDeclaration(path, state) {
-        path.traverse(TransformAsyncMethodsIntoGeneratorMethods, state);
-      },
-      ClassExpression(path, state) {
-        path.traverse(TransformAsyncMethodsIntoGeneratorMethods, state);
+
+        path.traverse(
+          {
+            ClassDeclaration(path, innerState) {
+              path.traverse(
+                TransformAsyncMethodsIntoGeneratorMethods,
+                innerState
+              );
+            },
+            ClassExpression(path, innerState) {
+              path.traverse(
+                TransformAsyncMethodsIntoGeneratorMethods,
+                innerState
+              );
+            },
+          },
+          state
+        );
       },
     },
   };


### PR DESCRIPTION
Closes #483

Even though the previous work on this (#490) correctly added a babel plugin ordering constraint, we were getting trolled by ordering conflicts due to how to Babel runs plugins visitors as it traverses the AST tree, which basically works like:

```
function traverseNodes(node) {
  ORDERED_BABEL_PLUGINS.forEach(plugin => {
    plugin.visitIfVisitorDeclared(node)
  })

  // recurse
  node.children.forEach(n => traverseNodes(n));
}
```

In other words, given an AST node, it'll go through each plugin in order and let that plugin `visit` the node if it has a visitor declared. Some babel plugins are implemented by defining a number of NodeType visitors, but Istanbul's plugin only defines a visitor for the root Program node and then deeply traverses the tree, and because, prior to this PR, the Ember Concurrency babel plugin relied on more leafward node visitors to do its job, Istanbul's deep-traverse-from-root was applying its transformations before EC.

The solution is also for EC to do a deep traversal from the root. I can imagine this causing some theoretical performance issues, but I don't know if it's worth measuring at this time. If it proves to be an issue then I can see it being feasible to for EC's plugin to switch between the old and new mode depending if whether known problematic plugins (e.g. istanbul) are present.