### PR TITLE
Remove (dummy-app only) dependency on ember-notify

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,6 @@
     "ember-fn-helper-polyfill": "^1.0.2",
     "ember-load-initializers": "^2.1.2",
     "ember-modifier": "^2.1.2",
-    "ember-notify": "https://github.com/adopted-ember-addons/ember-notify.git#c616e5b239a68c82b3d674bdb8f4db16a0687706",
     "ember-page-title": "^6.2.2",
     "ember-qunit": "^5.1.4",
     "ember-resolver": "^8.0.2",

--- a/tests/dummy/app/application/controller.js
+++ b/tests/dummy/app/application/controller.js
@@ -1,5 +1,6 @@
 import Controller from '@ember/controller';
 import config from '../config/environment';
+import { inject as service } from '@ember/service';
 
 const versionRegExp = /\d+[.]\d+[.]\d+(?:-(?:alpha|beta|rc)\.\d+)?/;
 const {
@@ -8,4 +9,6 @@ const {
 
 export default class ApplicationController extends Controller {
   addonVersion = version.match(versionRegExp)[0];
+
+  @service notifications;
 }

--- a/tests/dummy/app/application/template.hbs
+++ b/tests/dummy/app/application/template.hbs
@@ -24,4 +24,10 @@
 
 {{outlet}}
 
-<EmberNotify />
+<div class="notifications-container">
+  {{#each this.notifications.messages as |m|}}
+    <div class="notification {{m.severity}}">
+      {{m.message}}
+    </div>
+  {{/each}}
+</div>

--- a/tests/dummy/app/docs/examples/route-tasks/detail/route.js
+++ b/tests/dummy/app/docs/examples/route-tasks/detail/route.js
@@ -4,10 +4,11 @@ import { restartableTask, timeout } from 'ember-concurrency';
 
 // BEGIN-SNIPPET detail-route
 export default class RouteTasksDetailRoute extends Route {
-  @service notify;
+  @service notifications;
 
   setupController(controller, model) {
     super.setupController(...arguments);
+
     this.pollServerForChanges.perform(model.id);
   }
 
@@ -17,16 +18,16 @@ export default class RouteTasksDetailRoute extends Route {
   }
 
   pollServerForChanges = restartableTask(async (id) => {
-    let notify = this.notify;
+    let notifications = this.notifications;
     await timeout(500);
     try {
-      notify.info(`Thing ${id}: Starting to poll for changes`);
+      notifications.info(`Thing ${id}: Starting to poll for changes`);
       while (true) {
         await timeout(5000);
-        notify.info(`Thing ${id}: Polling now...`);
+        notifications.info(`Thing ${id}: Polling now...`);
       }
     } finally {
-      notify.warning(`Thing ${id}: No longer polling for changes`);
+      notifications.warning(`Thing ${id}: No longer polling for changes`);
     }
   });
 }

--- a/tests/dummy/app/docs/examples/route-tasks/template.hbs
+++ b/tests/dummy/app/docs/examples/route-tasks/template.hbs
@@ -33,10 +33,6 @@
 
 <ul>
   <li>
-    We use the <a href="https://github.com/aexmachina/ember-notify">ember-notify</a> Ember Addon
-    to display notifications using the <code>notify</code> service it provides.
-  </li>
-  <li>
     <code>setupController</code> kicks off the task with the current model id
   </li>
   <li>

--- a/tests/dummy/app/services/notifications.js
+++ b/tests/dummy/app/services/notifications.js
@@ -1,0 +1,24 @@
+import Service from '@ember/service';
+import { A } from '@ember/array';
+import { later } from '@ember/runloop';
+
+export default class NotificationsService extends Service {
+  messages = A();
+
+  notify(severity, message) {
+    const logObject = { severity, message };
+    this.messages.pushObject(logObject);
+
+    later(() => {
+      this.messages.removeObject(logObject);
+    }, 8000);
+  }
+
+  info(message) {
+    this.notify('info', message);
+  }
+
+  warning(message) {
+    this.notify('warning', message);
+  }
+}

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -102,10 +102,6 @@ button, .button {
                                   not supported by any browser */
 }
 
-.ember-notify {
-  background-color: rgba(255, 255, 255, 0.9);
-}
-
 th, td {
   min-width: 60px;
 }
@@ -240,4 +236,25 @@ th, td {
 
 .loading-spinner {
   display: inline-block;
+}
+
+.notifications-container {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+}
+
+.notification {
+  padding: 1rem;
+  border: 1px solid #aaa;
+  margin-bottom: 1rem;
+  background-color: white;
+
+  &.info {
+    color: #333;
+  }
+
+  &.warning {
+    color: red;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5377,7 +5377,7 @@ ember-cli-github-pages@^0.2.2:
     ember-cli-version-checker "^2.1.0"
     rsvp "^4.7.0"
 
-ember-cli-htmlbars@^5.3.2, ember-cli-htmlbars@^5.7.1:
+ember-cli-htmlbars@^5.7.1:
   version "5.7.2"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.2.tgz#e0cd2fb3c20d85fe4c3e228e6f0590ee1c645ba8"
   integrity sha512-Uj6R+3TtBV5RZoJY14oZn/sNPnc+UgmC8nb5rI4P3fR/gYoyTFIZSXiIM7zl++IpMoIrocxOrgt+mhonKphgGg==
@@ -5734,13 +5734,6 @@ ember-modifier@^2.1.2:
     ember-compatibility-helpers "^1.2.4"
     ember-destroyable-polyfill "^2.0.2"
     ember-modifier-manager-polyfill "^1.2.0"
-
-"ember-notify@https://github.com/adopted-ember-addons/ember-notify.git#c616e5b239a68c82b3d674bdb8f4db16a0687706":
-  version "6.0.1"
-  resolved "https://github.com/adopted-ember-addons/ember-notify.git#c616e5b239a68c82b3d674bdb8f4db16a0687706"
-  dependencies:
-    ember-cli-babel "^7.23.1"
-    ember-cli-htmlbars "^5.3.2"
 
 ember-page-title@^6.2.2:
   version "6.2.2"


### PR DESCRIPTION
We were only using this for the route-tasks page in the docs. Removing this to easy EC refactors now and in the future.

New treatment:

<img width="748" alt="Screen Shot 2023-04-03 at 3 24 38 PM" src="https://user-images.githubusercontent.com/81818/229608379-7cae8af8-6662-4ec5-86ea-d778b47e5119.png">
