### PR TITLE
Improve styling of code blocks on documentation site

### DIFF
--- a/tests/dummy/app/components/code-snippet/template.hbs
+++ b/tests/dummy/app/components/code-snippet/template.hbs
@@ -1,1 +1,5 @@
-<CodeBlock @code={{this.snippet.source}} @language={{this.language}} />
+<CodeBlock
+  @code={{this.snippet.source}}
+  @language={{this.language}}
+  class="code-snippet"
+/>

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -201,6 +201,16 @@ th, td {
   color: #bbb;
 }
 
+pre > code {
+  border: none;
+  margin: 0;
+  padding: 0 .5rem;
+}
+
+:not(pre) > code[class*="language-"], pre[class*="language-"] {
+  background-color: #f8f8f8;
+}
+
 .code-template-toggle {
   position: relative;
   background-color: #f8f8f8;

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -201,19 +201,15 @@ th, td {
   color: #bbb;
 }
 
-pre > code {
+.code-snippet {
   border: none;
   margin: 0;
   padding: 0 .5rem;
 }
 
-:not(pre) > code[class*="language-"], pre[class*="language-"] {
-  background-color: #f8f8f8;
-}
-
 .code-template-toggle {
   position: relative;
-  background-color: #f8f8f8;
+  background-color: #f5f2f0;
   pre {
     margin: 0 !important;
   }


### PR DESCRIPTION
Follow up to #522.

Cleaning up the styling of code blocks now that ember-prism is used.

Before: 
![image](https://user-images.githubusercontent.com/6216460/231402758-7babbe2e-ff68-460d-996d-89821f2a5318.png)

After:
 
![image](https://user-images.githubusercontent.com/6216460/231402791-9f5fbc98-7d06-43f2-ba6d-9d9a9723ec86.png)
