### PR TITLE
Fix this is undefined in benchmark.js

### DIFF
--- a/tests/dummy/app/task-modifiers/benchmark.js
+++ b/tests/dummy/app/task-modifiers/benchmark.js
@@ -15,11 +15,12 @@ function benchmarkModifier(taskFactory, option) {
       window.performance.mark(`${namespace}.start`);
 
       try {
-        yield* taskDefinition(...args);
+        const result = yield* fn.apply(this, args);
         window.performance.measure(
           `${namespace}.success`,
           `${namespace}.start`
         );
+        return result;
       } catch (e) {
         window.performance.measure(`${namespace}.error`, `${namespace}.start`);
         throw e;


### PR DESCRIPTION
Benchmark task-modifier was not working out of the box on my tasks. I had to make sure we are using the right this. I was inspired by what is done in ember-concurrency-retryable:

https://github.com/maxfierke/ember-concurrency-retryable/blob/4b18ccc073872d8a7592c4f1eb6c17461938334b/addon/-private/retryable-task-instance.js#L72