### PR TITLE
chore: add release notes todo link

### DIFF
--- a/tests/dummy/app/docs/typescript/template.hbs
+++ b/tests/dummy/app/docs/typescript/template.hbs
@@ -50,7 +50,7 @@
 </ul>
 
 <p>
-  TODO: link to Github V 2.3 release notes / upgrade guide.
+  See <a href="https://github.com/machty/ember-concurrency/blob/master/CHANGELOG.md#230">Github V 2.3 release notes</a> for upgrade guide and codemods.
 </p>
 
 <p>


### PR DESCRIPTION
Adds a link to the ec 2.3 release notes where a TODO currently exists