### PR TITLE
Add `waitFor` support to async arrow function API

### DIFF
--- a/addon/-private/async-arrow-runtime.js
+++ b/addon/-private/async-arrow-runtime.js
@@ -16,6 +16,13 @@ export function buildTask(contextFn, options, taskName, bufferPolicyName) {
 
   const result = contextFn();
 
+  if (optionsWithBufferPolicy && optionsWithBufferPolicy.waitFor) {
+    result.generator = optionsWithBufferPolicy.waitFor(result.generator);
+
+    optionsWithBufferPolicy = Object.assign({}, optionsWithBufferPolicy);
+    delete optionsWithBufferPolicy.waitFor;
+  }
+
   const taskFactory = new TaskFactory(
     taskName || '<unknown>',
     result.generator,

--- a/addon/index.d.ts
+++ b/addon/index.d.ts
@@ -796,6 +796,16 @@ type OptionTypeFor<T, F> = F extends (...args: infer Args) => T
 type TaskOptions = OptionsFor<TaskProperty<unknown, unknown[]>>;
 type TaskGroupOptions = OptionsFor<TaskGroupProperty<unknown>>;
 
+type AsyncArrowFunctionTaskOptions<
+  HostObject,
+  T,
+  Args extends any[]
+> = TaskOptions & {
+  waitFor?: (
+    fn: AsyncArrowTaskFunction<HostObject, T, Args>
+  ) => AsyncArrowTaskFunction<HostObject, T, Args>;
+};
+
 type MethodOrPropertyDecoratorWithParams<Params extends unknown[]> =
   MethodDecorator &
     PropertyDecorator &
@@ -919,7 +929,7 @@ export function task<
 
 export function task<
   HostObject,
-  O extends TaskOptions,
+  O extends AsyncArrowFunctionTaskOptions<HostObject, any, any[]>,
   T extends AsyncArrowTaskFunction<HostObject, any, any[]>
 >(
   hostObject: HostObject,
@@ -929,7 +939,7 @@ export function task<
 
 export function task<
   HostObject,
-  O extends TaskOptions,
+  O extends AsyncArrowFunctionTaskOptions<HostObject, any, any[]>,
   T extends AsyncArrowTaskFunction<HostObject, any, any[]>
 >(baseOptions: O, asyncArrowTaskFn: T): TaskForAsyncTaskFunction<HostObject, T>;
 
@@ -981,7 +991,7 @@ export function dropTask<
 >(asyncArrowTaskFn: T): TaskForAsyncTaskFunction<HostObject, T>;
 export function dropTask<
   HostObject,
-  O extends TaskOptions,
+  O extends AsyncArrowFunctionTaskOptions<HostObject, any, any[]>,
   T extends AsyncArrowTaskFunction<HostObject, any, any[]>
 >(baseOptions: O, asyncArrowTaskFn: T): TaskForAsyncTaskFunction<HostObject, T>;
 
@@ -1030,7 +1040,7 @@ export function enqueueTask<
 
 export function enqueueTask<
   HostObject,
-  O extends TaskOptions,
+  O extends AsyncArrowFunctionTaskOptions<HostObject, any, any[]>,
   T extends AsyncArrowTaskFunction<HostObject, any, any[]>
 >(baseOptions: O, asyncArrowTaskFn: T): TaskForAsyncTaskFunction<HostObject, T>;
 
@@ -1079,7 +1089,7 @@ export function keepLatestTask<
 
 export function keepLatestTask<
   HostObject,
-  O extends TaskOptions,
+  O extends AsyncArrowFunctionTaskOptions<HostObject, any, any[]>,
   T extends AsyncArrowTaskFunction<HostObject, any, any[]>
 >(baseOptions: O, asyncArrowTaskFn: T): TaskForAsyncTaskFunction<HostObject, T>;
 
@@ -1128,7 +1138,7 @@ export function restartableTask<
 
 export function restartableTask<
   HostObject,
-  O extends TaskOptions,
+  O extends AsyncArrowFunctionTaskOptions<HostObject, any, any[]>,
   T extends AsyncArrowTaskFunction<HostObject, any, any[]>
 >(baseOptions: O, asyncArrowTaskFn: T): TaskForAsyncTaskFunction<HostObject, T>;
 

--- a/tests/integration/async-arrow-task-test.js
+++ b/tests/integration/async-arrow-task-test.js
@@ -2,7 +2,14 @@ import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 // eslint-disable-next-line ember/no-computed-properties-in-native-classes
 import { computed, set } from '@ember/object';
-import { click, render, settled } from '@ember/test-helpers';
+import {
+  click,
+  getSettledState,
+  render,
+  settled,
+  waitUntil,
+} from '@ember/test-helpers';
+import { waitFor } from '@ember/test-waiters';
 import { hbs } from 'ember-cli-htmlbars';
 import {
   task,
@@ -138,6 +145,36 @@ module('Integration | async-arrow-task', function (hooks) {
     await startTest(assert);
 
     resolve('Wow!');
+
+    await finishTest(assert);
+  });
+
+  test('waitFor option', async function (assert) {
+    assert.expect(9);
+
+    let { promise, resolve } = defer();
+
+    this.owner.register(
+      'component:test-async-arrow-task',
+      class extends TestComponent {
+        myTask = task(this, { waitFor }, async (arg) => {
+          set(this, 'resolved', await promise);
+          assert.strictEqual(this.myTask.name, 'myTask');
+          return arg;
+        });
+      }
+    );
+
+    await render(hbs`<TestAsyncArrowTask />`);
+    click('button#start');
+    await waitUntil(() => this.element.textContent.includes('Running!'));
+
+    assert.true(getSettledState().hasPendingWaiters);
+
+    resolve('Wow!');
+    await settled();
+
+    assert.false(getSettledState().hasPendingWaiters);
 
     await finishTest(assert);
   });

--- a/tests/types/ember-concurrency-test.ts
+++ b/tests/types/ember-concurrency-test.ts
@@ -58,6 +58,7 @@ import {
 } from 'ember-concurrency';
 import { expectTypeOf as expect } from 'expect-type';
 import { taskFor } from 'ember-concurrency-ts';
+import { waitFor } from '@ember/test-waiters';
 
 declare type TestCallback = () => void | Promise<void>;
 declare function module(description: string, callback: TestCallback): void;
@@ -3128,6 +3129,7 @@ module('integration tests', () => {
       debug = task(this, { debug: true }, async () => {});
       onState = task(this, { onState: () => {} }, async () => {});
       onStateNull = task(this, { onState: null }, async () => {});
+      waitFor = task({ waitFor }, async () => {});
 
       // Note: these options work even when strictFunctionTypes is enabled, but
       // turning it on in this repo breaks other things in addon/index.d.ts
@@ -3237,6 +3239,7 @@ module('integration tests', () => {
       debug = task({ debug: true }, async () => {});
       onState = task({ onState: () => {} }, async () => {});
       onStateNull = task({ onState: null }, async () => {});
+      waitFor = task({ waitFor }, async () => {});
 
       // Note: these options work even when strictFunctionTypes is enabled, but
       // turning it on in this repo breaks other things in addon/index.d.ts
@@ -3409,6 +3412,7 @@ module('integration tests', () => {
       debug = task({ debug: true }, async () => {});
       onState = task({ onState: () => {} }, async () => {});
       onStateNull = task({ onState: null }, async () => {});
+      waitFor = task({ waitFor }, async () => {});
 
       // Note: these options work even when strictFunctionTypes is enabled, but
       // turning it on in this repo breaks other things in addon/index.d.ts


### PR DESCRIPTION
I am opening this PR to start a discussion. There is currently no way I can find to wrap async arrow function tasks in a test waiter a la `waitFor` from `@ember/test-waiters`. So this is a stab at adding support for that -- see the commit message for an explanation of this solution.

I haven't updated any documentation or anything because I want to see if this is a direction we want to pursue first.

A couple of alternatives I thought of:
1. Figure out how to make the babel plugin smarter so it can recognize when the task function is wrapped in a "modifier function," e.g. `myTask = task(waitFor(async () => { /* ... */ }));` would produce `{ generator: waitFor(function*() { /* ... */ }) }`. This seems sketchy because in the source code the modifier function would be called with an `async` function while in the transpiled code it would be called with a generator function. This happens to work for `waitFor`, but providing generic support for modifier functions like this would come with a pretty screwy caveat that they must support being passed generator functions even though they must be typed to accept `async` functions.
1. Make the options interface more generic -- define a type/interface for these sorts of modifier functions like `waitFor` and then do something like `myTask = task({ modifiers: [ waitFor ] }, async () => { /* ... */ });`. This would allow us to type the modifier functions to accept a generator function without running into trouble because the un-transpiled source code would never _invoke_  the modifier function. On the other hand, it complicates the syntax and it's not clear there will ever be a need for other modifier functions like this. I'm happy to explore this route if we prefer -- I don't think it would be much more work.
1. Just say we no longer support wrapping tasks in test waiters this way, and tell users to either wrap each promise in a `waitForPromise()` call, or work with the `@ember/test-waiters` maintainers to try to devise some other easy way to wrap `ember-concurrency` tasks.

I'm very interested to hear folks' thoughts as my app relies heavily on `@waitFor`, and I really love the async arrow function syntax and want to move to it soon as I can figure out what to do about the `@waitFor`s!

Related to #513