### PR TITLE
docs: Insert link to release notes wrt taskFor() deprecation

### DIFF
--- a/tests/dummy/app/docs/typescript/template.hbs
+++ b/tests/dummy/app/docs/typescript/template.hbs
@@ -45,13 +45,9 @@
       <a href="https://github.com/chancancode/ember-concurrency-ts">ember-concurrency-ts</a>
     </strong>
     and the <code>taskFor()</code> function it provides is no longer necessary
-    for interacting with tasks declared using the new syntax.
+    for interacting with tasks declared using the new syntax. See <a href="https://github.com/machty/ember-concurrency/releases/tag/2.3.0">v2.3.0</a> and <a href="https://github.com/machty/ember-concurrency/releases/tag/2.3.2">v2.3.2</a> release notes.
   </li>
 </ul>
-
-<p>
-  TODO: link to Github V 2.3 release notes / upgrade guide.
-</p>
 
 <p>
   If you would like to see the TypeScript guides for older versions of ember-concurrency


### PR DESCRIPTION
- Link to v2.3.0 and v2.3.2 as they both have important information
- Removes one TODO :)