### PR TITLE
Simplify ts snippets by using the same import statements for `import Component from `@glimmer/component`

### DIFF
--- a/packages/test-app/snippets/ts/basic-example.ts
+++ b/packages/test-app/snippets/ts/basic-example.ts
@@ -1,4 +1,4 @@
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 import { task, timeout } from '../../../ember-concurrency/declarations';
 
 export default class extends Component {

--- a/packages/test-app/snippets/ts/template-import-example.txt
+++ b/packages/test-app/snippets/ts/template-import-example.txt
@@ -1,10 +1,10 @@
-import GlimmerComponent from "@glimmer/component";
+import Component from "@glimmer/component";
 import { task } from "ember-concurrency";
 import perform from "ember-concurrency/helpers/perform";
 import { on } from "@ember/modifier";
 import { fn } from "@ember/helper";
 
-export default class Demo extends GlimmerComponent {
+export default class Demo extends Component {
   taskNoArgs = task(async () => {
     console.log("Look ma, no args!");
   });


### PR DESCRIPTION
Currently, all three ts-snippets had different ways of importing `Component`:

https://github.com/machty/ember-concurrency/blob/8e0c0379d6fa99a38c137ddd16345c60ebd3abba/packages/test-app/snippets/ts/basic-example.ts#L1

https://github.com/machty/ember-concurrency/blob/8e0c0379d6fa99a38c137ddd16345c60ebd3abba/packages/test-app/snippets/ts/template-import-example.txt#L1

https://github.com/machty/ember-concurrency/blob/8e0c0379d6fa99a38c137ddd16345c60ebd3abba/packages/test-app/snippets/ts/typing-task.ts#L1

The third one is the "standard" way, from the [ember guides](https://guides.emberjs.com/release/components/component-state-and-actions/#toc_tracked-properties), so I changed the first two to align with that.