### PR TITLE
Fix missing @babel/helper-module-imports dependency

### DIFF
--- a/packages/ember-concurrency/package.json
+++ b/packages/ember-concurrency/package.json
@@ -101,6 +101,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "@babel/helper-module-imports": "^7.22.15",
     "@babel/helper-plugin-utils": "^7.12.13",
     "@babel/types": "^7.12.13",
     "decorator-transforms": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
 
   packages/ember-concurrency:
     dependencies:
+      '@babel/helper-module-imports':
+        specifier: ^7.22.15
+        version: 7.22.15
       '@babel/helper-plugin-utils':
         specifier: ^7.12.13
         version: 7.22.5


### PR DESCRIPTION
This came up as that dependency imported from the transform [here](https://github.com/machty/ember-concurrency/blob/master/packages/ember-concurrency/async-arrow-task-transform.js#L19) not getting resolved in a strict pnpm environment (no hoisting).