### PR TITLE
Fix PressAndHold component for mobile

### DIFF
--- a/packages/test-app/app/components/press-and-hold-button.gts
+++ b/packages/test-app/app/components/press-and-hold-button.gts
@@ -16,11 +16,9 @@ export default class PressAndHoldButtonComponent extends Component<PressAndHoldB
   <template>
     <button
       {{! template-lint-disable no-pointer-down-event-binding }}
-      {{on 'touchstart' @press}}
-      {{on 'mousedown' @press}}
-      {{on 'touchend' @release}}
-      {{on 'mouseleave' @release}}
-      {{on 'mouseup' @release}}
+      {{on 'pointerdown' @press}}
+      {{on 'pointerup' @release}}
+      {{on 'pointercancel' @release}}
       type='button'
     >
       {{yield}}

--- a/packages/test-app/app/components/press-and-hold-button.gts
+++ b/packages/test-app/app/components/press-and-hold-button.gts
@@ -19,6 +19,7 @@ export default class PressAndHoldButtonComponent extends Component<PressAndHoldB
       {{on 'pointerdown' @press}}
       {{on 'pointerup' @release}}
       {{on 'pointercancel' @release}}
+      {{on 'pointerleave' @release}}
       type='button'
     >
       {{yield}}


### PR DESCRIPTION
This PR replaces the mouse/touch events with pointer events.

Fixes #607 