### PR TITLE
Allow the async arrow task transform to run under Babel 8

### DIFF
--- a/packages/ember-concurrency/async-arrow-task-transform.js
+++ b/packages/ember-concurrency/async-arrow-task-transform.js
@@ -331,7 +331,7 @@ function cleanupUnusedTaskFactoryImports(programPath, usedTaskFactories) {
 }
 
 module.exports = declare((api) => {
-  api.assertVersion(7);
+  api.assertVersion('^7.0.0 || ^8.0.0');
 
   return {
     name: 'transform-ember-concurrency-async-function-tasks',

--- a/packages/ember-concurrency/package.json
+++ b/packages/ember-concurrency/package.json
@@ -100,9 +100,9 @@
     "test": "tests"
   },
   "dependencies": {
-    "@babel/helper-module-imports": "^7.22.15",
-    "@babel/helper-plugin-utils": "^7.12.13",
-    "@babel/types": "^7.12.13",
+    "@babel/helper-module-imports": "^7.22.15 || ^8.0.0",
+    "@babel/helper-plugin-utils": "^7.12.13 || ^8.0.0",
+    "@babel/types": "^7.12.13 || ^8.0.0",
     "decorator-transforms": "^1.0.1",
     "@embroider/addon-shim": "^1.8.7"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,13 +15,13 @@ importers:
   packages/ember-concurrency:
     dependencies:
       '@babel/helper-module-imports':
-        specifier: ^7.22.15
+        specifier: ^7.22.15 || ^8.0.0
         version: 7.27.1
       '@babel/helper-plugin-utils':
-        specifier: ^7.12.13
+        specifier: ^7.12.13 || ^8.0.0
         version: 7.27.1
       '@babel/types':
-        specifier: ^7.12.13
+        specifier: ^7.12.13 || ^8.0.0
         version: 7.28.2
       '@embroider/addon-shim':
         specifier: ^1.8.7


### PR DESCRIPTION
*Written and opened by Claude, an AI agent, working on @wagenet's behalf. The words below are the agent's, not theirs.*

---

`async-arrow-task-transform.js` calls `api.assertVersion(7)`, which throws under `@babel/core` 8:

```
Requires Babel "^7.0.0-0", but was loaded with "8.0.1"
```

That assertion is the only thing blocking Babel 8. This widens it to `'^7.0.0 || ^8.0.0'` and widens the `@babel/helper-module-imports`, `@babel/helper-plugin-utils`, and `@babel/types` ranges to match. Lockfile specifiers change; resolved versions don't. It doesn't move the repo itself onto Babel 8.

### Evidence

The patched transform was run against the same input under `@babel/core` 7.29.7 (7.x helpers) and 8.0.1 (8.x helpers). Output was byte-for-byte identical. Input covered `task`, `restartableTask`, `dropTask` with an options object, `enqueueTask`, and a `keepLatestTask(async function () {})` that the transform correctly left untouched while pruning the transformed factories from the import. Reverting just the assertion line reproduces the throw under 8.0.1.

The transform uses `@babel/types` builders, `path.scope.getBinding`, and `addNamed`, none of which changed between 7 and 8 in ways that affect it.

### No test added

The test suite is browser QUnit via `ember test`, and the toolchain around it is on Babel 7. Covering this in CI would need a Node test runner plus an aliased second `@babel/core` install, which is a lot of new machinery for a one-line change. It's maybe a `node --test` file and a CI step if you'd rather have it.

`pnpm lint` passes. `pnpm test:ember --launch chrome`: 133 tests, 0 failures.

### Context

This blocks a Babel 8 upgrade in a large downstream Ember monorepo, where it's the only Babel plugin with a hard `assertVersion(7)` gate.
